### PR TITLE
Auto-rebuild a stale client build in fluster chill

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ fluster logs
 # Export results
 fluster export --cluster-run 1 -o results.csv
 
-# Launch the visualization UI
+# Launch the visualization UI (auto-rebuilds the client when it's out of date; --no-rebuild to skip)
 fluster chill
 
 # Cancel a stuck job (--force for orphaned jobs)

--- a/fluster/cli.py
+++ b/fluster/cli.py
@@ -531,11 +531,38 @@ def serve(
     uvicorn.run(fastapi_app, host=host, port=port)
 
 
+# Config files (alongside client/src/) whose timestamps mark the build as stale.
+_CLIENT_BUILD_CONFIG_FILES = ("package.json", "svelte.config.js", "vite.config.ts", "tsconfig.json")
+
+
+def _client_build_is_stale(client_dir: Path) -> bool:
+    """True if the built client bundle is missing or older than any source file."""
+    build_file = client_dir / "build" / "index.js"
+    if not build_file.is_file():
+        return True
+    build_mtime = build_file.stat().st_mtime
+
+    sources = list((client_dir / "src").rglob("*"))
+    sources += [client_dir / name for name in _CLIENT_BUILD_CONFIG_FILES]
+    for path in sources:
+        try:
+            if path.is_file() and path.stat().st_mtime > build_mtime:
+                return True
+        except OSError:
+            continue
+    return False
+
+
 @app.command()
 def chill(
     port: int = typer.Option(3000, "--port", help="Port to serve on."),
     host: str = typer.Option("127.0.0.1", "--host", help="Bind address."),
     dev: bool = typer.Option(False, "--dev", help="Run SvelteKit dev server instead of production build."),
+    no_rebuild: bool = typer.Option(
+        False,
+        "--no-rebuild",
+        help="Don't auto-rebuild a stale client; serve the existing build (error if missing).",
+    ),
 ):
     """Launch the fluster visualization UI for the active project."""
     project_name = _resolve_project()
@@ -561,12 +588,34 @@ def chill(
     if dev:
         cmd = ["npm", "run", "dev", "--", "--port", str(port), "--host", host]
     else:
-        if not (client_dir / "build" / "index.js").is_file():
-            logger.error(
-                "Client not built. Run 'npm run build' in the client/ directory, "
-                "or use --dev for the dev server."
+        build_file = client_dir / "build" / "index.js"
+        stale = _client_build_is_stale(client_dir)
+        if stale and no_rebuild:
+            if not build_file.is_file():
+                logger.error(
+                    "Client not built. Run 'npm run build' in the client/ directory, "
+                    "or use --dev for the dev server."
+                )
+                raise typer.Exit(code=1)
+            logger.warning(
+                "Client build is stale (source newer than build/). Serving anyway; "
+                "run 'npm run build' in client/ to pick up the latest changes."
             )
-            raise typer.Exit(code=1)
+        elif stale:
+            if build_file.is_file():
+                logger.warning("Client build is stale (source newer than build/).")
+            else:
+                logger.info("Client not built yet.")
+            logger.info("Rebuilding client (npm run build)...")
+            try:
+                build = subprocess.run(["npm", "run", "build"], cwd=client_dir)
+            except FileNotFoundError:
+                logger.error("npm not found. Install Node.js/npm, or use --dev / --no-rebuild.")
+                raise typer.Exit(code=1)
+            if build.returncode != 0:
+                logger.error("Client build failed. See the output above, or use --dev.")
+                raise typer.Exit(code=build.returncode)
+            logger.info("Rebuild complete.")
         cmd = ["node", "build/index.js"]
 
     url = f"http://{host}:{port}"

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -1,11 +1,12 @@
-"""Tests for CLI commands: run, jobs, job, cancel."""
+"""Tests for CLI commands: run, jobs, job, cancel, chill."""
 
-from unittest.mock import patch
+import os
+from unittest.mock import MagicMock, patch
 
 import pytest
 from typer.testing import CliRunner
 
-from fluster.cli import app
+from fluster.cli import app, _client_build_is_stale
 from fluster.config import settings
 from fluster.config.project import create_project, project_dir, project_exists, set_active_project
 from fluster.db.connection import connect
@@ -145,3 +146,99 @@ def test_delete_aborted(named_project):
     result = runner.invoke(app, ["delete", "test-proj"], input="n\n")
     assert result.exit_code == 1  # typer.confirm(abort=True) exits with 1
     assert project_exists("test-proj")
+
+
+# --- fluster chill ---
+
+_BUILD_EPOCH = 1_000_000_000  # fixed base mtime so freshness is deterministic
+
+
+def _make_client_dir(tmp_path, *, built=True, stale=False):
+    """Build a fake client/ tree with controlled mtimes for staleness tests."""
+    client = tmp_path / "client"
+    (client / "src").mkdir(parents=True)
+    src = client / "src" / "app.css"
+    src.write_text("/* x */")
+    config = client / "package.json"
+    config.write_text("{}")
+
+    if built:
+        build_file = client / "build" / "index.js"
+        build_file.parent.mkdir(parents=True)
+        build_file.write_text("// built")
+        os.utime(build_file, (_BUILD_EPOCH, _BUILD_EPOCH))
+        src_mtime = _BUILD_EPOCH + 10 if stale else _BUILD_EPOCH - 10
+        os.utime(src, (src_mtime, src_mtime))
+        os.utime(config, (src_mtime, src_mtime))
+    return client
+
+
+def _chill_cmds(mock_run):
+    """The command list passed to each subprocess.run call, in order."""
+    return [call.args[0] for call in mock_run.call_args_list]
+
+
+def test_client_build_is_stale_when_missing(tmp_path):
+    assert _client_build_is_stale(_make_client_dir(tmp_path, built=False)) is True
+
+
+def test_client_build_is_stale_when_source_newer(tmp_path):
+    assert _client_build_is_stale(_make_client_dir(tmp_path, built=True, stale=True)) is True
+
+
+def test_client_build_is_fresh_when_build_newer(tmp_path):
+    assert _client_build_is_stale(_make_client_dir(tmp_path, built=True, stale=False)) is False
+
+
+@patch("fluster.cli.subprocess.run")
+def test_chill_stale_auto_rebuilds(mock_run, named_project, tmp_path, monkeypatch):
+    mock_run.return_value = MagicMock(returncode=0)
+    monkeypatch.setattr(settings, "CLIENT_DIR", _make_client_dir(tmp_path, built=True, stale=True))
+    result = runner.invoke(app, ["chill"])
+    assert result.exit_code == 0
+    assert _chill_cmds(mock_run) == [["npm", "run", "build"], ["node", "build/index.js"]]
+
+
+@patch("fluster.cli.subprocess.run")
+def test_chill_fresh_serves_without_rebuild(mock_run, named_project, tmp_path, monkeypatch):
+    mock_run.return_value = MagicMock(returncode=0)
+    monkeypatch.setattr(settings, "CLIENT_DIR", _make_client_dir(tmp_path, built=True, stale=False))
+    result = runner.invoke(app, ["chill"])
+    assert result.exit_code == 0
+    assert _chill_cmds(mock_run) == [["node", "build/index.js"]]
+
+
+@patch("fluster.cli.subprocess.run")
+def test_chill_no_rebuild_serves_stale(mock_run, named_project, tmp_path, monkeypatch):
+    mock_run.return_value = MagicMock(returncode=0)
+    monkeypatch.setattr(settings, "CLIENT_DIR", _make_client_dir(tmp_path, built=True, stale=True))
+    result = runner.invoke(app, ["chill", "--no-rebuild"])
+    assert result.exit_code == 0
+    assert _chill_cmds(mock_run) == [["node", "build/index.js"]]
+
+
+@patch("fluster.cli.subprocess.run")
+def test_chill_no_rebuild_missing_build_errors(mock_run, named_project, tmp_path, monkeypatch):
+    mock_run.return_value = MagicMock(returncode=0)
+    monkeypatch.setattr(settings, "CLIENT_DIR", _make_client_dir(tmp_path, built=False))
+    result = runner.invoke(app, ["chill", "--no-rebuild"])
+    assert result.exit_code == 1
+    mock_run.assert_not_called()
+
+
+@patch("fluster.cli.subprocess.run")
+def test_chill_failed_rebuild_exits_before_serving(mock_run, named_project, tmp_path, monkeypatch):
+    mock_run.return_value = MagicMock(returncode=2)
+    monkeypatch.setattr(settings, "CLIENT_DIR", _make_client_dir(tmp_path, built=True, stale=True))
+    result = runner.invoke(app, ["chill"])
+    assert result.exit_code == 2
+    assert _chill_cmds(mock_run) == [["npm", "run", "build"]]
+
+
+@patch("fluster.cli.subprocess.run")
+def test_chill_dev_mode_skips_staleness(mock_run, named_project, tmp_path, monkeypatch):
+    mock_run.return_value = MagicMock(returncode=0)
+    monkeypatch.setattr(settings, "CLIENT_DIR", _make_client_dir(tmp_path, built=False))
+    result = runner.invoke(app, ["chill", "--dev"])
+    assert result.exit_code == 0
+    assert _chill_cmds(mock_run) == [["npm", "run", "dev", "--", "--port", "3000", "--host", "127.0.0.1"]]


### PR DESCRIPTION
Closes #10.

## Problem

`fluster chill` (production mode) ran `node build/index.js` after only checking that the build *existed* — never whether it was current. After updating the client source, the stale bundle kept getting served with no warning, so merged UI changes silently didn't appear. This bit us right after #6: the fix was just `npm run build`, but nothing signaled that.

## Change

When the built client is out of date, `chill` now **auto-rebuilds by default** before serving.

- **`_client_build_is_stale(client_dir)`** (`fluster/cli.py`) — `True` if `build/index.js` is missing or older than any file under `client/src/` or the key client config files (`package.json`, `svelte.config.js`, `vite.config.ts`, `tsconfig.json`). Simple mtime comparison, no hashing.
- **`chill`** — if stale, logs a clear warning and runs `npm run build` before serving (with friendly errors for missing `npm` and for a failed build). A new **`--no-rebuild`** flag skips the rebuild and instead warns + serves the existing build, or errors if there's no build at all.
- **`--dev` is unaffected** (Vite already hot-reloads from source).

## Behavior

\`\`\`
$ fluster chill
WARN  Client build is stale (source newer than build/).
INFO  Rebuilding client (npm run build)...
INFO  Rebuild complete.
INFO  Launching fluster UI ... at http://127.0.0.1:3000

$ fluster chill --no-rebuild      # warn + serve the stale build (error if none)
\`\`\`

## Tests

`chill` had no coverage before. Added (`tests/test_cli_commands.py`), using mtime-controlled fake client dirs + patched `subprocess.run`:
- `_client_build_is_stale` directly (missing / source-newer / build-newer)
- stale → auto-rebuild then serve
- fresh → serve without rebuild
- `--no-rebuild` + stale → warn + serve, no build
- `--no-rebuild` + missing build → exit 1
- failed rebuild → exit before serving
- `--dev` → skips staleness entirely

`uv run pytest -q`: 203 passed (+9 new). The 2 pre-existing clustering-param failures on `main` (`test_cluster_stores_params`, `test_default_clustering`) are unrelated to this change.

## Docs

`README.md` — note that `chill` auto-rebuilds the client when out of date.

## Out of scope

- No standalone `fluster build` command.
- No change to `--dev`.
- No build-content hashing — mtime is sufficient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)