### PR TITLE
Add UMAP options to `fluster plan`

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ fluster init my-project
 # Set up your API key (stored in ~/.fluster/secrets.yaml)
 fluster config
 
-# Tweak the plan if you want (embedding model, LLM, clustering params)
+# Tweak the plan if you want (embedding model, LLM, UMAP + clustering params)
 fluster plan
 
 # Ingest a CSV — file_path column is optional

--- a/fluster/cli.py
+++ b/fluster/cli.py
@@ -13,7 +13,7 @@ from rich.table import Table
 
 from fluster import __version__
 from fluster.config import settings
-from fluster.config.plan import load_plan, save_plan, Plan, LLMProvider
+from fluster.config.plan import load_plan, save_plan, Plan, LLMProvider, UMAPReduction
 from fluster.config.project import (
     create_project,
     delete_project,
@@ -260,6 +260,36 @@ def plan_cmd():
 
         cluster.method = method_choice
 
+        # UMAP reduction options. n_neighbors and min_dist are shared across all
+        # UMAP reductions; target_dimensions is prompted per reduction since the
+        # 2D (visualization) and higher-D (clustering) reductions differ.
+        umap_reductions = [r for r in plan.reductions if isinstance(r, UMAPReduction)]
+        if umap_reductions:
+            n_neighbors = typer.prompt(
+                "UMAP n_neighbors", default=umap_reductions[0].n_neighbors, type=int,
+            )
+            if n_neighbors < 2:
+                console.print("[red]n_neighbors must be >= 2.[/red]")
+                raise typer.Exit(code=1)
+
+            min_dist = typer.prompt(
+                "UMAP min_dist", default=umap_reductions[0].min_dist, type=float,
+            )
+            if not 0.0 <= min_dist < 1.0:
+                console.print("[red]min_dist must be in [0.0, 1.0).[/red]")
+                raise typer.Exit(code=1)
+
+            for reduction in umap_reductions:
+                reduction.n_neighbors = n_neighbors
+                reduction.min_dist = min_dist
+                reduction.target_dimensions = typer.prompt(
+                    f"UMAP target_dimensions for the {reduction.target_dimensions}D reduction",
+                    default=reduction.target_dimensions, type=int,
+                )
+                if reduction.target_dimensions < 2:
+                    console.print("[red]target_dimensions must be >= 2.[/red]")
+                    raise typer.Exit(code=1)
+
         caption = plan.images.caption
         caption = typer.confirm("Caption images with FastVLM?", default=caption)
         plan.images.caption = caption
@@ -269,6 +299,13 @@ def plan_cmd():
         console.print(f"  LLM:        {plan.llm.provider.value} / {plan.llm.model}")
         params_str = ", ".join(f"{k}={v}" for k, v in cluster.params.items())
         console.print(f"  Clustering:  method={cluster.method}, {params_str}")
+        if umap_reductions:
+            dims = ", ".join(f"{r.target_dimensions}D" for r in umap_reductions)
+            u = umap_reductions[0]
+            console.print(
+                f"  UMAP:        n_neighbors={u.n_neighbors}, "
+                f"min_dist={u.min_dist}, dimensions=[{dims}]"
+            )
         console.print(f"  Images:      caption={'on' if caption else 'off'}")
 
 

--- a/fluster/config/plan.py
+++ b/fluster/config/plan.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from enum import Enum
 from pathlib import Path
-from typing import Literal
+from typing import Annotated, Literal
 
 import yaml
 from pydantic import BaseModel, Field
@@ -27,9 +27,13 @@ class UMAPReduction(BaseModel):
     method: Literal["umap"] = "umap"
     target_dimensions: int = 2
     random_state: int = SEED
+    n_neighbors: int = 15  # capped at n_samples - 1 at fit time
+    min_dist: float = 0.1
 
 
-ReductionConfig = PCAReduction | UMAPReduction
+ReductionConfig = Annotated[
+    PCAReduction | UMAPReduction, Field(discriminator="method")
+]
 
 
 class HDBSCANParams(BaseModel):

--- a/fluster/pipeline/reduce.py
+++ b/fluster/pipeline/reduce.py
@@ -164,9 +164,14 @@ def reduce_items(
                 skipped += 1
                 continue
 
-            # UMAP needs n_neighbors <= n_samples.
+            # UMAP needs n_neighbors <= n_samples; cap the configured value.
             n_samples = working.shape[0]
-            n_neighbors = min(15, n_samples - 1) if n_samples > 1 else 1
+            n_neighbors = (
+                min(reduction_config.n_neighbors, n_samples - 1)
+                if n_samples > 1
+                else 1
+            )
+            min_dist = reduction_config.min_dist
 
             # Spectral init fails when n_samples is very small; fall back to random.
             init = "spectral" if n_samples > n_neighbors + 1 else "random"
@@ -174,6 +179,7 @@ def reduce_items(
             reducer = UMAP(
                 n_components=target,
                 n_neighbors=n_neighbors,
+                min_dist=min_dist,
                 random_state=random_state,
                 init=init,
             )
@@ -188,6 +194,7 @@ def reduce_items(
                 {
                     "n_components": target,
                     "n_neighbors": n_neighbors,
+                    "min_dist": min_dist,
                     "random_state": random_state,
                 },
                 item_ids, coords,

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -145,3 +145,22 @@ def test_delete_aborted(named_project):
     result = runner.invoke(app, ["delete", "test-proj"], input="n\n")
     assert result.exit_code == 1  # typer.confirm(abort=True) exits with 1
     assert project_exists("test-proj")
+
+
+# --- fluster plan: UMAP options (issue #8) ---
+
+
+def test_plan_sets_umap_options(named_project):
+    from fluster.config.plan import load_plan
+
+    # Prompt order: provider, model, method, 4 hdbscan params,
+    # UMAP n_neighbors, UMAP min_dist, target_dims x2, caption confirm.
+    inp = "\n\n\n\n\n\n\n25\n0.2\n\n\ny\n"
+    result = runner.invoke(app, ["plan"], input=inp)
+    assert result.exit_code == 0, result.output
+
+    plan = load_plan(project_dir(named_project) / settings.PLAN_YAML)
+    umaps = [r for r in plan.reductions if r.method == "umap"]
+    assert umaps
+    assert all(r.n_neighbors == 25 for r in umaps)
+    assert all(r.min_dist == 0.2 for r in umaps)

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -131,3 +131,23 @@ def test_custom_clustering_params():
     )
     assert config.params["min_cluster_size"] == 10
     assert config.params["min_samples"] == 3
+
+
+# --- UMAP options (issue #8) ---
+
+
+def test_umap_default_options():
+    umap = Plan().reductions[1]
+    assert isinstance(umap, UMAPReduction)
+    assert umap.n_neighbors == 15
+    assert umap.min_dist == 0.1
+
+
+def test_umap_options_roundtrip(tmp_path):
+    plan = Plan()
+    plan.reductions = [UMAPReduction(target_dimensions=2, n_neighbors=30, min_dist=0.25)]
+    path = tmp_path / "plan.yaml"
+    save_plan(plan, path)
+    loaded = load_plan(path)
+    assert loaded.reductions[0].n_neighbors == 30
+    assert loaded.reductions[0].min_dist == 0.25

--- a/tests/test_reduce.py
+++ b/tests/test_reduce.py
@@ -207,3 +207,39 @@ def test_reduce_is_deterministic(project):
     for a, b in zip(coords_first, coords_second):
         assert a["item_id"] == b["item_id"]
         assert json.loads(a["coordinates_json"]) == json.loads(b["coordinates_json"])
+
+
+# --- UMAP options (issue #8) ---
+
+
+def test_reduce_umap_custom_options_stored(project):
+    pdir, conn = project
+    _setup_items(pdir, conn)
+
+    plan = Plan(reductions=[
+        UMAPReduction(target_dimensions=2, n_neighbors=10, min_dist=0.3),
+    ])
+    reduce_items(conn, plan)
+
+    umap = conn.execute(
+        "SELECT params_json FROM reductions WHERE method = 'umap'"
+    ).fetchone()
+    params = json.loads(umap["params_json"])
+    assert params["n_neighbors"] == 10
+    assert params["min_dist"] == 0.3
+
+
+def test_reduce_umap_caps_n_neighbors(project):
+    pdir, conn = project
+    _setup_items(pdir, conn, count=5)
+
+    plan = Plan(reductions=[
+        UMAPReduction(target_dimensions=2, n_neighbors=100),
+    ])
+    reduce_items(conn, plan)
+
+    umap = conn.execute(
+        "SELECT params_json FROM reductions WHERE method = 'umap'"
+    ).fetchone()
+    params = json.loads(umap["params_json"])
+    assert params["n_neighbors"] == 4  # capped at n_samples - 1


### PR DESCRIPTION
Implements #8 — UMAP reductions can now be tuned interactively through `fluster plan`.

## What changed
- **`fluster plan`** prompts for UMAP options: `n_neighbors` and `min_dist` (shared across all UMAP reductions), plus `target_dimensions` prompted per reduction (the 2D viz and higher-D clustering passes legitimately differ). Inputs are validated at prompt time (`n_neighbors >= 2`, `min_dist` in `[0.0, 1.0)`, `target_dimensions >= 2`), and the plan summary echoes the chosen UMAP settings.
- **`UMAPReduction` model** gains `n_neighbors` (default 15) and `min_dist` (default 0.1).
- **`reduce.py`** threads these into the UMAP fit (`n_neighbors` still capped at `n_samples - 1`) and records `min_dist` in `params_json`.
- **Discriminated-union fix:** `ReductionConfig` is now an explicit `Field(discriminator="method")` union. Once `UMAPReduction`'s non-method fields all had defaults, a serialized PCA reduction could round-trip back as a UMAP under pydantic's smart-union matching — this removes that silent config corruption.

## Tests
- New tests across `test_plan.py` (defaults + YAML round-trip), `test_reduce.py` (param pass-through + `n_neighbors` cap), and `test_cli_commands.py` (end-to-end prompt-driven plan edit).
- Full suite: **199 passing**. Two failures remain (`test_default_clustering`, `test_cluster_stores_params`) — both are **pre-existing on `main`**, unrelated to this change (verified: they fail identically with this branch's changes stashed; they assert a `min_cluster_size: 5` clustering default the model doesn't provide).

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)