### PR TITLE
Add a cluster detail drawer to the run-detail page

### DIFF
--- a/client/src/lib/components/ClusterDrawer.svelte
+++ b/client/src/lib/components/ClusterDrawer.svelte
@@ -1,0 +1,156 @@
+<script lang="ts">
+	import Pill from './Pill.svelte';
+
+	type Cluster = {
+		clusterId: number;
+		label: string;
+		size: number;
+		shortLabel: string;
+		rationale: string;
+		keywords: string[];
+		provider: string;
+		model: string;
+	};
+
+	interface Props {
+		cluster: Cluster;
+		color: string;
+		onClose: () => void;
+	}
+
+	let { cluster, color, onClose }: Props = $props();
+</script>
+
+<div class="drawer">
+	<div class="drawer-header">
+		<h3>Cluster Detail</h3>
+		<button onclick={onClose}>&times;</button>
+	</div>
+
+	<div class="drawer-body stack">
+		<div class="title-row">
+			<span class="swatch" style="background: {color}"></span>
+			<span class="title-text">
+				<span class="muted">#{cluster.clusterId}</span>
+				{cluster.label}
+			</span>
+		</div>
+
+		{#if cluster.shortLabel}
+			<div class="field">
+				<span class="muted">Short Label</span>
+				<span class="field-value">{cluster.shortLabel}</span>
+			</div>
+		{/if}
+
+		<div class="field">
+			<span class="muted">Size</span>
+			<span class="field-value">{cluster.size}</span>
+		</div>
+
+		{#if cluster.rationale}
+			<div class="field">
+				<span class="muted">Rationale</span>
+				<p class="rationale">{cluster.rationale}</p>
+			</div>
+		{/if}
+
+		{#if cluster.keywords.length > 0}
+			<div class="field">
+				<span class="muted">Keywords</span>
+				<div class="keywords">
+					{#each cluster.keywords as keyword}
+						<Pill size="sm" variant="info">{keyword}</Pill>
+					{/each}
+				</div>
+			</div>
+		{/if}
+
+		<div class="field">
+			<span class="muted">Provider</span>
+			<span class="field-value">{cluster.provider}</span>
+		</div>
+
+		<div class="field">
+			<span class="muted">Model</span>
+			<span class="field-value">{cluster.model}</span>
+		</div>
+	</div>
+</div>
+
+<style>
+	.drawer {
+		position: absolute;
+		top: 0;
+		right: 0;
+		width: 28rem;
+		height: 100%;
+		overflow-y: auto;
+		padding: 1rem;
+		z-index: 7;
+		background: rgba(10, 10, 15, 0.92);
+		backdrop-filter: blur(8px);
+		-webkit-backdrop-filter: blur(8px);
+		border-left: 1px solid var(--color-fg-secondary);
+	}
+
+	.drawer-header {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		margin-bottom: 0.75rem;
+	}
+
+	.drawer-header h3 {
+		margin: 0;
+	}
+
+	.drawer-header button {
+		font-size: 1.25rem;
+		padding: 0.25rem 0.5rem;
+		line-height: 1;
+	}
+
+	.drawer-body {
+		font-size: 0.875rem;
+	}
+
+	.title-row {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+	}
+
+	.title-text {
+		font-weight: 600;
+	}
+
+	.swatch {
+		display: inline-block;
+		width: 0.875rem;
+		height: 0.875rem;
+		border-radius: 2px;
+		flex-shrink: 0;
+	}
+
+	.field {
+		display: flex;
+		flex-direction: column;
+		gap: 0.25rem;
+	}
+
+	.field-value {
+		font-weight: 600;
+	}
+
+	.rationale {
+		margin: 0;
+		line-height: 1.5;
+	}
+
+	.keywords {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.375rem;
+	}
+</style>

--- a/client/src/lib/server/db/schema.ts
+++ b/client/src/lib/server/db/schema.ts
@@ -137,6 +137,8 @@ export const clusterSummaries = sqliteTable("cluster_summaries", {
 	clusterSummaryId: integer("cluster_summary_id").primaryKey({ autoIncrement: true }),
 	clusterRunId: integer("cluster_run_id").notNull().references(() => clusterRuns.clusterRunId),
 	clusterId: integer("cluster_id").notNull(),
+	provider: text().notNull(),
+	model: text().notNull(),
 	label: text().notNull(),
 	labelJson: text("label_json").notNull(),
 	createdAt: text("created_at").default(sql`(datetime('now'))`).notNull(),

--- a/client/src/lib/server/queries/runs.ts
+++ b/client/src/lib/server/queries/runs.ts
@@ -64,11 +64,38 @@ export function getClusterDetails(clusterRunId: number) {
 		.orderBy(clusterSummaries.clusterId)
 		.all();
 
-	return labels.map((l) => ({
-		clusterId: l.clusterId,
-		label: l.label,
-		size: sizeMap.get(l.clusterId) ?? 0
-	}));
+	return labels.map((l) => {
+		const detail = parseLabelJson(l.labelJson);
+		return {
+			clusterId: l.clusterId,
+			label: l.label,
+			size: sizeMap.get(l.clusterId) ?? 0,
+			shortLabel: detail.short_label,
+			rationale: detail.rationale,
+			keywords: detail.keywords,
+			provider: l.provider,
+			model: l.model
+		};
+	});
+}
+
+type LabelJson = {
+	short_label: string;
+	rationale: string;
+	keywords: string[];
+};
+
+function parseLabelJson(labelJson: string): LabelJson {
+	try {
+		const parsed = JSON.parse(labelJson) as Partial<LabelJson>;
+		return {
+			short_label: parsed.short_label ?? '',
+			rationale: parsed.rationale ?? '',
+			keywords: Array.isArray(parsed.keywords) ? parsed.keywords : []
+		};
+	} catch {
+		return { short_label: '', rationale: '', keywords: [] };
+	}
 }
 
 export type CritiqueData = {

--- a/client/src/routes/runs/[clusterRunId]/+page.svelte
+++ b/client/src/routes/runs/[clusterRunId]/+page.svelte
@@ -5,6 +5,7 @@
 	import Input from '$lib/components/Input.svelte';
 	import ScatterPlot from '$lib/components/ScatterPlot.svelte';
 	import ItemDrawer from '$lib/components/ItemDrawer.svelte';
+	import ClusterDrawer from '$lib/components/ClusterDrawer.svelte';
 	import { createClusterColorScale } from '$lib/cluster-colors';
 	import { formatTime, formatPercent } from '$lib/format';
 
@@ -48,6 +49,10 @@
 	const parsedParams: Record<string, unknown> = $derived.by(() => {
 		try { return JSON.parse(data.run.paramsJson); } catch { return {}; }
 	});
+
+	const focusedCluster = $derived(
+		focusClusterId == null ? null : (data.clusters.find((c) => c.clusterId === focusClusterId) ?? null)
+	);
 
 	const inspectedCluster = $derived.by(() => {
 		if (inspectItemId == null) return null;
@@ -146,6 +151,8 @@
 
 		{#if inspectItemId != null}
 			<ItemDrawer itemId={inspectItemId} clusterId={inspectedCluster?.clusterId} clusterLabel={inspectedCluster?.label} onClose={() => inspectItemId = null} />
+		{:else if focusedCluster}
+			<ClusterDrawer cluster={focusedCluster} color={getClusterColor(focusedCluster.clusterId)} onClose={() => focusClusterId = null} />
 		{/if}
 
 		{#if showCritique && data.critique}


### PR DESCRIPTION
## Summary

Selecting a cluster row on `/runs/[clusterRunId]` previously only highlighted the corresponding points on the scatter plot. Now that selection also opens a slide-in **cluster detail drawer**, surfacing richer label metadata that `getClusterDetails` already loaded from `label_json` but then discarded.

The drawer is entirely **prop-driven** — it reuses data already present in the page load, so there's no new API route or server round-trip. It displays the cluster's `short_label`, `rationale`, `keywords` (as info pills), `provider`, and `model`, alongside the existing label and size.

Exemplar items and membership-probability stats are explicitly deferred (both would need new joins).

## Changes

- **`schema.ts`** — `clusterSummaries` Drizzle table gains `provider`/`model` columns to match the Python-side DB schema (`fluster/db/schema.py`).
- **`runs.ts`** — `getClusterDetails` parses `label_json` via a small, defensive `parseLabelJson` helper (tolerates malformed/partial JSON), exposing `short_label`/`rationale`/`keywords` and passing `provider`/`model` through.
- **`ClusterDrawer.svelte`** — new component modeled on `ItemDrawer` for visual/structural consistency; keywords rendered as `Pill`s.
- **`+page.svelte`** — wires the drawer in. `ItemDrawer` takes precedence: when an item is being inspected its drawer shows; the cluster drawer only appears when a cluster is focused without an item under inspection (mutually exclusive, no overlap).

## Testing

- `npm run check` — no new errors (one pre-existing `ItemDrawer.svelte` error unchanged on main).
- `npm run build` — succeeds.
- Python suite unaffected (change is client-only).

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)