### PR TITLE
Fix two pre-existing clustering-default test failures (issue #15)

### DIFF
--- a/fluster/config/plan.py
+++ b/fluster/config/plan.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Annotated, Literal
 
 import yaml
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from fluster.config.settings import SEED
 
@@ -52,6 +52,14 @@ class ClusteringConfig(BaseModel):
     method: Literal["hdbscan", "agglomerative"] = "hdbscan"
     reduction: str = "umap_8d"  # Format: "{method}_{dimensions}d"
     params: dict = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def _apply_method_defaults(self) -> ClusteringConfig:
+        # Fill the HDBSCAN default only when no params are given, keeping the
+        # default scoped to its method so params never leak across methods.
+        if not self.params and self.method == "hdbscan":
+            self.params = {"min_cluster_size": 5}
+        return self
 
 
 class ImageConfig(BaseModel):


### PR DESCRIPTION
## Summary

Fixes the two tests that have been failing on `main` since commit `12ef902`, where `ClusteringConfig.params` defaulted to an empty dict instead of `{"min_cluster_size": 5}`.

`12ef902` ("isolate clustering parameters between HDBSCAN and agglomerative methods") correctly stopped HDBSCAN params from leaking into agglomerative runs, but dropped the HDBSCAN default entirely in the process — breaking:

- `tests/test_plan.py::test_default_clustering`
- `tests/test_cluster.py::test_cluster_stores_params`

## Approach

Restores `min_cluster_size=5` as the HDBSCAN default **without reintroducing the leak**. Instead of a plain `default_factory` (which would apply the param to every method, including agglomerative), the default is scoped per-method via a Pydantic `model_validator(mode="after")` on `ClusteringConfig`. It fills `params={"min_cluster_size": 5}` only when params is empty **and** method is `"hdbscan"`, leaving agglomerative and any explicitly-provided params untouched.

This is the option that pins behavior fluster owns (vs. silently delegating to the hdbscan library default, which could drift).

## Testing

- The two failing tests pass **as written** — they were not modified.
- Full suite: **210 passing**.

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)