### PR TITLE
Pull cluster exemplars from the edges, not just the dense core

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 - Generate embeddings
 - Reduce dimensions (PCA + UMAP)
 - Cluster (HDBSCAN or agglomerative)
-- Select representative exemplars per cluster
+- Select exemplars from each cluster's core and outskirts
 - Label clusters with an LLM (BYO)
 - Critique the clustering run
 - Keep an auditable trail of every step

--- a/fluster/cli.py
+++ b/fluster/cli.py
@@ -24,6 +24,7 @@ from fluster.config.project import (
     set_active_project,
 )
 from fluster.db.connection import connect
+from fluster.db.schema import apply_schema
 from fluster.jobs.manager import (
     create_job,
     fail_job,
@@ -467,6 +468,8 @@ def cancel(
 def reset():
     """Clear pipeline outputs (embeddings, clusters, etc.) so the next run starts fresh."""
     with _open_project() as (project_path, conn):
+        # Listed child-first so each table's rows are gone before its parent is
+        # dropped (DROP does an implicit DELETE under foreign_keys=ON).
         tables = [
             "cluster_run_critiques",
             "cluster_summaries",
@@ -479,8 +482,13 @@ def reset():
             "embeddings",
             "representations",
         ]
+        # DROP rather than DELETE so schema changes to these derived tables are
+        # picked up: apply_schema recreates them with the current DDL. (The
+        # vec_embeddings virtual table is recreated by embed, not apply_schema.)
         for table in tables:
-            conn.execute(f"DELETE FROM {table}")
+            conn.execute(f"DROP TABLE IF EXISTS {table}")
+        conn.commit()
+        apply_schema(conn)
         conn.commit()
         typer.echo("Pipeline outputs cleared. Run 'fluster run' to re-process.")
 

--- a/fluster/db/schema.py
+++ b/fluster/db/schema.py
@@ -152,6 +152,7 @@ CREATE TABLE IF NOT EXISTS cluster_exemplars (
     cluster_run_id  INTEGER NOT NULL,
     cluster_id      INTEGER NOT NULL,
     item_id         INTEGER NOT NULL,
+    kind            TEXT NOT NULL,
     rank            INTEGER NOT NULL,
     score           REAL NOT NULL,
     PRIMARY KEY (cluster_run_id, cluster_id, item_id),

--- a/fluster/pipeline/exemplars.py
+++ b/fluster/pipeline/exemplars.py
@@ -8,8 +8,10 @@ from fluster.pipeline.reduce import load_embedding_vectors
 
 # Default number of nearest-to-centroid candidates to consider.
 _N_CANDIDATES = 20
-# Default number of exemplars to select per cluster.
+# Default number of center exemplars (most typical) to select per cluster.
 _TOP_K = 3
+# Default number of outskirt exemplars (near the cluster's edges) to select per cluster.
+_OUTSKIRTS_K = 2
 
 
 def _load_item_vectors(conn: sqlite3.Connection) -> dict[int, np.ndarray]:
@@ -34,14 +36,22 @@ def _select_for_cluster(
     vectors: dict[int, np.ndarray],
     n_candidates: int,
     top_k: int,
-) -> list[tuple[int, int, float]]:
-    """Select exemplars for a single cluster.
+    outskirts_k: int,
+) -> list[tuple[int, str, int, float]]:
+    """Select center and outskirt exemplars for a single cluster.
+
+    Center exemplars are the cluster's most typical members; outskirt
+    exemplars sit near its edges. Showing both to the labeler keeps labels
+    from over-fitting to the dense core.
 
     Algorithm:
-    1. Compute centroid of cluster members in embedding space
-    2. Pick top C nearest-to-centroid candidates
-    3. Score each candidate by avg cosine similarity to all cluster members
-    4. Return top K as (item_id, rank, score)
+    1. Compute centroid of cluster members in embedding space.
+    2. Center: of the C nearest-to-centroid candidates, take the top K by
+       avg cosine similarity to all members. score = that avg similarity.
+    3. Outskirt: take the members with the lowest centroid similarity
+       (excluding center picks). score = centroid similarity; rank 1 is the
+       most peripheral.
+    4. Return each as (item_id, kind, rank, score), ranked 1.. within kind.
     """
     member_vecs = np.array([vectors[member_id] for member_id in member_ids], dtype=np.float32)
     centroid = member_vecs.mean(axis=0)
@@ -51,23 +61,40 @@ def _select_for_cluster(
     member_norms = member_vecs / (np.linalg.norm(member_vecs, axis=1, keepdims=True) + 1e-10)
     centroid_sims = member_norms @ centroid_norm
 
-    # Pick top N candidates nearest to centroid.
+    # --- Center: nearest-to-centroid candidates, scored by avg similarity to members.
     candidate_count = min(n_candidates, len(member_ids))
     candidate_indices = np.argsort(-centroid_sims)[:candidate_count]
 
-    # Score each candidate by avg similarity to all cluster members.
-    scores = []
+    center_scores = []
     for idx in candidate_indices:
-        candidate_vec = member_norms[idx]
-        sims = member_norms @ candidate_vec
-        avg_sim = float(sims.mean())
-        scores.append((member_ids[idx], avg_sim))
+        avg_sim = float((member_norms @ member_norms[idx]).mean())
+        center_scores.append((member_ids[idx], avg_sim))
 
-    # Sort by score descending, take top K.
-    scores.sort(key=lambda x: -x[1])
-    selection_count = min(top_k, len(scores))
+    center_scores.sort(key=lambda x: -x[1])
+    center = center_scores[: min(top_k, len(center_scores))]
+    center_ids = {item_id for item_id, _ in center}
 
-    return [(item_id, rank + 1, score) for rank, (item_id, score) in enumerate(scores[:selection_count])]
+    selected = [
+        (item_id, "center", rank + 1, score)
+        for rank, (item_id, score) in enumerate(center)
+    ]
+
+    # --- Outskirts: lowest centroid similarity, excluding members already chosen as center.
+    outskirts = []
+    for idx in np.argsort(centroid_sims):
+        item_id = member_ids[idx]
+        if item_id in center_ids:
+            continue
+        outskirts.append((item_id, float(centroid_sims[idx])))
+        if len(outskirts) >= outskirts_k:
+            break
+
+    selected += [
+        (item_id, "outskirt", rank + 1, score)
+        for rank, (item_id, score) in enumerate(outskirts)
+    ]
+
+    return selected
 
 
 def select_exemplars(
@@ -75,6 +102,7 @@ def select_exemplars(
     cluster_run_id: int,
     n_candidates: int = _N_CANDIDATES,
     top_k: int = _TOP_K,
+    outskirts_k: int = _OUTSKIRTS_K,
 ) -> dict:
     """Select exemplars for every cluster in a cluster run.
 
@@ -103,14 +131,14 @@ def select_exemplars(
 
     all_exemplars = []
     for cluster_id, member_ids in clusters.items():
-        exemplars = _select_for_cluster(member_ids, vectors, n_candidates, top_k)
-        for item_id, rank, score in exemplars:
-            all_exemplars.append((cluster_run_id, cluster_id, item_id, rank, score))
+        exemplars = _select_for_cluster(member_ids, vectors, n_candidates, top_k, outskirts_k)
+        for item_id, kind, rank, score in exemplars:
+            all_exemplars.append((cluster_run_id, cluster_id, item_id, kind, rank, score))
 
     conn.executemany(
         "INSERT INTO cluster_exemplars "
-        "(cluster_run_id, cluster_id, item_id, rank, score) "
-        "VALUES (?, ?, ?, ?, ?)",
+        "(cluster_run_id, cluster_id, item_id, kind, rank, score) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
         all_exemplars,
     )
     conn.commit()

--- a/fluster/pipeline/label.py
+++ b/fluster/pipeline/label.py
@@ -19,12 +19,11 @@ class ClusterLabel(BaseModel):
 
 _EXEMPLAR_TEXT_LIMIT = 500  # chars; keeps LLM prompt size manageable
 
-_PROMPT_TEMPLATE = """You are labeling a cluster of items. Below are representative examples (exemplars) from the cluster, along with the cluster size.
+_PROMPT_TEMPLATE = """You are labeling a cluster of items. Below are example items sampled from the cluster of {cluster_size} members. Some are central (the most typical members); others are from the cluster's outskirts (near its edges).
 
 Cluster size: {cluster_size}
 
-Exemplar texts:
-{exemplar_texts}
+{exemplar_sections}
 
 Respond with a JSON object containing:
 - "label": A descriptive label for this cluster (1-5 words)
@@ -48,20 +47,46 @@ def _get_clusters(conn: sqlite3.Connection, cluster_run_id: int) -> list[tuple[i
 
 def _get_exemplar_texts(
     conn: sqlite3.Connection, cluster_run_id: int, cluster_id: int
-) -> list[str]:
-    """Get embedding_text for each exemplar in a cluster, ordered by rank."""
+) -> dict[str, list[str]]:
+    """Get exemplar embedding_text grouped by kind ('center' / 'outskirt').
+
+    Each group is ordered by rank.
+    """
     rows = conn.execute(
         """
-        SELECT r.text
+        SELECT ce.kind, r.text
         FROM cluster_exemplars ce
         JOIN representations r ON r.item_id = ce.item_id
             AND r.representation_type = 'embedding_text'
         WHERE ce.cluster_run_id = ? AND ce.cluster_id = ?
-        ORDER BY ce.rank
+        ORDER BY ce.kind, ce.rank
         """,
         (cluster_run_id, cluster_id),
     ).fetchall()
-    return [r["text"][:_EXEMPLAR_TEXT_LIMIT] for r in rows]
+
+    grouped: dict[str, list[str]] = {"center": [], "outskirt": []}
+    for row in rows:
+        grouped.setdefault(row["kind"], []).append(row["text"][:_EXEMPLAR_TEXT_LIMIT])
+    return grouped
+
+
+def _format_exemplar_sections(grouped: dict[str, list[str]]) -> str:
+    """Render center/outskirt exemplar texts into labeled prompt sections.
+
+    Omits a section when it has no exemplars (e.g. tiny clusters with no
+    distinct outskirts).
+    """
+    sections = []
+    for kind, heading, noun in (
+        ("center", "Central examples (most typical of the cluster):", "Central"),
+        ("outskirt", "Outskirts examples (near the cluster's edges):", "Outskirts"),
+    ):
+        texts = grouped.get(kind, [])
+        if not texts:
+            continue
+        body = "\n---\n".join(f"[{noun} example {i+1}]\n{text}" for i, text in enumerate(texts))
+        sections.append(f"{heading}\n{body}")
+    return "\n\n".join(sections)
 
 
 def _label_exists(
@@ -102,17 +127,16 @@ def label_clusters(
         if _label_exists(conn, cluster_run_id, cluster_id, config):
             skipped += 1
             continue
-        exemplar_texts = _get_exemplar_texts(conn, cluster_run_id, cluster_id)
+        grouped = _get_exemplar_texts(conn, cluster_run_id, cluster_id)
+        exemplar_sections = _format_exemplar_sections(grouped)
 
-        if not exemplar_texts:
+        if not exemplar_sections:
             skipped += 1
             continue
 
         prompt = _PROMPT_TEMPLATE.format(
             cluster_size=cluster_size,
-            exemplar_texts="\n---\n".join(
-                f"[Exemplar {i+1}]\n{text}" for i, text in enumerate(exemplar_texts)
-            ),
+            exemplar_sections=exemplar_sections,
         )
 
         result = generate_json(

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -128,6 +128,30 @@ def test_cancel_finished_job(named_project):
     assert row["cancel_requested_at"] is None  # Should NOT be set on finished job.
 
 
+# --- fluster reset ---
+
+
+def test_reset_drops_and_clears_derived_tables(named_project):
+    pdir = project_dir(named_project)
+    conn = connect(pdir)
+    conn.execute(
+        "INSERT INTO reductions (embedding_reference, method, target_dimensions) "
+        "VALUES ('emb', 'pca', 2)"
+    )
+    conn.commit()
+    conn.close()
+
+    # DROP + recreate must not error under foreign_keys=ON (correct child-first order).
+    result = runner.invoke(app, ["reset"])
+    assert result.exit_code == 0
+
+    conn = connect(pdir)
+    # The probe row is gone and the derived tables are queryable again (recreated).
+    assert conn.execute("SELECT COUNT(*) FROM reductions").fetchone()[0] == 0
+    assert conn.execute("SELECT COUNT(*) FROM cluster_exemplars").fetchone()[0] == 0
+    conn.close()
+
+
 # --- fluster delete ---
 
 

--- a/tests/test_exemplars.py
+++ b/tests/test_exemplars.py
@@ -6,7 +6,7 @@ from fluster.config.plan import Plan
 from fluster.db.connection import connect
 from fluster.pipeline.cluster import cluster_items
 from fluster.pipeline.embed import embed_items
-from fluster.pipeline.exemplars import select_exemplars
+from fluster.pipeline.exemplars import _select_for_cluster, select_exemplars
 from fluster.pipeline.ingest import ingest_rows
 from fluster.pipeline.materialize import materialize_items
 from fluster.pipeline.reduce import reduce_items
@@ -65,16 +65,16 @@ def test_exemplars_have_valid_ranks(project):
 
     exemplars = conn.execute(
         "SELECT * FROM cluster_exemplars WHERE cluster_run_id = ? "
-        "ORDER BY cluster_id, rank",
+        "ORDER BY cluster_id, kind, rank",
         (run_id,),
     ).fetchall()
 
-    # Ranks should start at 1 and be sequential per cluster.
-    by_cluster: dict[int, list] = {}
+    # Ranks should start at 1 and be sequential per (cluster, kind) group.
+    by_group: dict[tuple[int, str], list] = {}
     for e in exemplars:
-        by_cluster.setdefault(e["cluster_id"], []).append(e)
+        by_group.setdefault((e["cluster_id"], e["kind"]), []).append(e)
 
-    for cluster_id, entries in by_cluster.items():
+    for (cluster_id, kind), entries in by_group.items():
         ranks = [e["rank"] for e in entries]
         assert ranks == list(range(1, len(ranks) + 1))
 
@@ -120,17 +120,19 @@ def test_exemplars_respect_top_k(project):
     pdir, conn = project
     run_id = _setup_clustered(pdir, conn)
 
-    select_exemplars(conn, run_id, top_k=2)
+    select_exemplars(conn, run_id, top_k=2, outskirts_k=1)
 
-    by_cluster = {}
+    by_cluster: dict[int, dict[str, int]] = {}
     for e in conn.execute(
         "SELECT * FROM cluster_exemplars WHERE cluster_run_id = ?",
         (run_id,),
     ).fetchall():
-        by_cluster.setdefault(e["cluster_id"], []).append(e)
+        counts = by_cluster.setdefault(e["cluster_id"], {})
+        counts[e["kind"]] = counts.get(e["kind"], 0) + 1
 
-    for cluster_id, entries in by_cluster.items():
-        assert len(entries) <= 2
+    for cluster_id, counts in by_cluster.items():
+        assert counts.get("center", 0) <= 2
+        assert counts.get("outskirt", 0) <= 1
 
 
 # --- Idempotency ---
@@ -175,20 +177,73 @@ def test_exemplars_exclude_noise(project):
 # --- Scores are ordered ---
 
 def test_exemplars_ranked_by_score(project):
-    """Within each cluster, rank 1 should have the highest score."""
+    """Center exemplars rank by descending score (most typical first); outskirt
+    exemplars rank by ascending centroid similarity (most peripheral first)."""
     pdir, conn = project
     run_id = _setup_clustered(pdir, conn)
 
     select_exemplars(conn, run_id)
 
-    by_cluster = {}
+    by_group: dict[tuple[int, str], list] = {}
     for e in conn.execute(
         "SELECT * FROM cluster_exemplars WHERE cluster_run_id = ? "
-        "ORDER BY cluster_id, rank",
+        "ORDER BY cluster_id, kind, rank",
         (run_id,),
     ).fetchall():
-        by_cluster.setdefault(e["cluster_id"], []).append(e)
+        by_group.setdefault((e["cluster_id"], e["kind"]), []).append(e)
 
-    for cluster_id, entries in by_cluster.items():
+    for (cluster_id, kind), entries in by_group.items():
         scores = [e["score"] for e in entries]
-        assert scores == sorted(scores, reverse=True)
+        if kind == "center":
+            assert scores == sorted(scores, reverse=True)
+        else:
+            assert scores == sorted(scores)
+
+
+# --- Center / outskirt split ---
+
+def test_exemplars_have_both_kinds(project):
+    """A run over varied data should yield both center and outskirt exemplars,
+    and the two sets should be disjoint."""
+    pdir, conn = project
+    run_id = _setup_clustered(pdir, conn)
+
+    select_exemplars(conn, run_id)
+
+    rows = conn.execute(
+        "SELECT item_id, kind FROM cluster_exemplars WHERE cluster_run_id = ?",
+        (run_id,),
+    ).fetchall()
+    kinds = {r["kind"] for r in rows}
+    assert kinds == {"center", "outskirt"}
+
+    centers = {r["item_id"] for r in rows if r["kind"] == "center"}
+    outskirts = {r["item_id"] for r in rows if r["kind"] == "outskirt"}
+    assert centers.isdisjoint(outskirts)
+
+
+def test_select_for_cluster_separates_core_from_edges():
+    """With a tight core and a few far-flung members, center exemplars come from
+    the core and outskirt exemplars from the edges."""
+    import numpy as np
+
+    # Five near-identical core members around [1, 0], two distant edge members.
+    vectors = {
+        1: np.array([1.0, 0.0], dtype=np.float32),
+        2: np.array([0.99, 0.01], dtype=np.float32),
+        3: np.array([0.98, 0.02], dtype=np.float32),
+        4: np.array([1.0, 0.03], dtype=np.float32),
+        5: np.array([0.97, 0.0], dtype=np.float32),
+        6: np.array([-1.0, 1.0], dtype=np.float32),
+        7: np.array([-0.8, 1.2], dtype=np.float32),
+    }
+    member_ids = list(vectors.keys())
+
+    selected = _select_for_cluster(member_ids, vectors, n_candidates=20, top_k=3, outskirts_k=2)
+
+    center_ids = {item_id for item_id, kind, _, _ in selected if kind == "center"}
+    outskirt_ids = {item_id for item_id, kind, _, _ in selected if kind == "outskirt"}
+
+    assert outskirt_ids == {6, 7}
+    assert center_ids <= {1, 2, 3, 4, 5}
+    assert center_ids.isdisjoint(outskirt_ids)

--- a/tests/test_label.py
+++ b/tests/test_label.py
@@ -198,7 +198,9 @@ def test_label_prompt_includes_exemplars(mock_call, project):
 
     label_clusters(conn, run_id, _llm_config())
 
-    # Check that the prompt sent to the LLM contains exemplar text.
+    # Check that the prompt sent to the LLM contains exemplar text, split into
+    # central and outskirts sections, plus the cluster size.
     prompt_sent = mock_call.call_args_list[0][0][0]
-    assert "Exemplar" in prompt_sent
+    assert "Central example" in prompt_sent
+    assert "Outskirts example" in prompt_sent
     assert "Cluster size:" in prompt_sent


### PR DESCRIPTION
## Summary

Cluster labels were coming out **more specific than the data beneath them** — names that fit a cluster's core tightly but excluded its marginal members. The cause was upstream of the labeler: exemplar selection (`_select_for_cluster`) is a faux-medoid that only ever surfaced the dense **core** (nearest-centroid candidates ranked by avg similarity to members). The LLM then generalized from the most typical items and produced over-specific labels.

This change feeds the labeler **both ends** of each cluster, and lets the visible spread of the data — not an instruction — keep labels honest.

## Changes

- **Outskirt exemplars** (`fluster/pipeline/exemplars.py`): alongside the existing **center** exemplars, `_select_for_cluster` now returns **outskirt** exemplars — in-cluster members with the *lowest* centroid similarity, excluding anything already chosen as center. New `_OUTSKIRTS_K=2` default and `outskirts_k` param. The per-exemplar tuple grows a `kind` field: `(item_id, kind, rank, score)`. Center ranks by descending avg similarity (most typical first); outskirts by ascending centroid similarity (most peripheral first).
- **Schema** (`fluster/db/schema.py`): `cluster_exemplars` gains a `kind TEXT NOT NULL` column, edited directly into the DDL — no migration (project convention).
- **Labeling prompt** (`fluster/pipeline/label.py`): presents `Central examples` and `Outskirts examples` as separate labeled sections and states they're a *sample* of the cluster's members. **Deliberately does not instruct the model to generalize** — showing the genuine marginal items is what constrains over-specificity. Empty sections (tiny clusters with no distinct outskirts) are omitted.
- **`fluster reset`** (`fluster/cli.py`): switched from `DELETE FROM` to `DROP TABLE IF EXISTS` (child-first for FK safety under `foreign_keys=ON`) followed by `apply_schema`. The normal `reset` + `run` workflow now picks up schema changes to derived tables — so the new `kind` column needs no manual intervention.

## Testing

- Full suite green (**213 passed**).
- Exemplar rank/score assertions split per kind; new tests for kind split + disjointness, a `_select_for_cluster` core-vs-edge unit test on synthetic vectors, a prompt-section check, and a `reset` DROP/recreate test (verifies no FK violation).

## Out of scope (deferred)

- Max-min sampling for outskirt diversity.
- Dispersion/radius signal to the LLM.
- Instructing the LLM to produce broader labels.

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)