### PR TITLE
Add automatic LLM-driven cluster merging (issue #1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,10 @@ fluster jobs
 fluster job 1
 fluster logs
 
+# Over-segmented? Let an LLM fold redundant clusters into a new derived run
+# (non-destructive — the source run is left untouched). --force to redo.
+fluster merge --cluster-run 1
+
 # Export results
 fluster export --cluster-run 1 -o results.csv
 

--- a/fluster/cli.py
+++ b/fluster/cli.py
@@ -39,6 +39,7 @@ from fluster.jobs.manager import (
 )
 from fluster.pipeline.export import export_cluster_run
 from fluster.pipeline.ingest import ingest_rows
+from fluster.pipeline.merge import merge_clusters
 from fluster.pipeline.run import PipelineCancelled, run_pipeline
 
 console = Console()
@@ -546,6 +547,41 @@ def export(
         except ValueError as exc:
             logger.error(str(exc))
             raise typer.Exit(code=1)
+
+
+@app.command()
+def merge(
+    cluster_run: int = typer.Option(..., "--cluster-run", help="Source cluster run ID to merge."),
+    force: bool = typer.Option(
+        False, "--force", help="Create a new merged run even if one already exists.",
+    ),
+):
+    """Auto-merge a labeled cluster run's redundant clusters into a new run."""
+    with _open_project() as (project_path, conn):
+        plan = load_plan(project_path / settings.PLAN_YAML)
+        try:
+            summary = merge_clusters(conn, cluster_run, plan.llm, force=force)
+        except ValueError as exc:
+            logger.error(str(exc))
+            raise typer.Exit(code=1)
+
+        if summary["skipped"]:
+            if "cluster_run_id" in summary:
+                console.print(
+                    f"Cluster run {cluster_run} already has merged run "
+                    f"{summary['cluster_run_id']}. Use --force to create another."
+                )
+            else:
+                console.print(f"No clusters were merged ({summary.get('reason', 'nothing to do')}).")
+            return
+
+        console.print(
+            f"Created merged cluster run [bold]{summary['cluster_run_id']}[/bold] "
+            f"({summary['n_clusters_before']} → {summary['n_clusters_after']} clusters)."
+        )
+        for group in summary["merges"]:
+            sources = ", ".join(str(cid) for cid in group["source_cluster_ids"])
+            console.print(f"  merged [{sources}] → cluster {group['new_cluster_id']}: {group['rationale']}")
 
 
 @app.command()

--- a/fluster/pipeline/merge.py
+++ b/fluster/pipeline/merge.py
@@ -1,0 +1,291 @@
+"""merge_clusters — LLM-driven, non-destructive merging of cluster runs.
+
+Given a finished, labeled cluster run, an LLM reads every cluster's label +
+rationale + keywords and decides which clusters should be folded together. The
+merges are applied into a NEW derived ``cluster_runs`` row (``method="merged"``)
+that records its parent and the merge groups it applied in ``params_json`` — the
+source run is never mutated, so merges are non-destructive and stackable.
+
+A merged run points at the same ``reduction_id`` as its parent, so every
+downstream consumer (exemplars, labeling, critique, export, server) works
+against it with no special-casing. Noise (``cluster_id = -1``) is always carried
+over and never merged.
+"""
+
+import json
+import sqlite3
+
+from pydantic import BaseModel
+
+from fluster.config.plan import LLMConfig
+from fluster.llm.client import generate_json
+from fluster.pipeline.exemplars import select_exemplars
+from fluster.pipeline.label import label_clusters
+
+# Minimum number of resulting non-noise clusters; the auto-merge will never
+# collapse a run below this floor.
+_MIN_RESULTING_CLUSTERS = 2
+
+
+class MergeGroup(BaseModel):
+    cluster_ids: list[int]
+    rationale: str
+
+
+class MergeDecision(BaseModel):
+    merges: list[MergeGroup]
+
+
+_PROMPT_TEMPLATE = """You are reviewing the clusters of a clustering run to decide which clusters describe the SAME underlying concept and should be merged.
+
+Below is every cluster with its label, rationale, keywords, and size:
+{clusters}
+
+Merge only clusters that are clearly redundant — different facets or wordings of the same concept. Be conservative: when in doubt, leave clusters separate. Do not merge clusters that are merely related or adjacent. It is perfectly acceptable to return no merges.
+
+Respond with a JSON object containing:
+- "merges": An array of merge groups. Each group is an object with:
+    - "cluster_ids": An array of 2 or more cluster IDs (integers) to fold together
+    - "rationale": A brief explanation (1-2 sentences) of why they describe the same concept
+
+Every cluster ID may appear in at most one group. Respond ONLY with the JSON object, no other text."""
+
+
+def _get_run(conn: sqlite3.Connection, cluster_run_id: int) -> sqlite3.Row | None:
+    return conn.execute(
+        "SELECT * FROM cluster_runs WHERE cluster_run_id = ?",
+        (cluster_run_id,),
+    ).fetchone()
+
+
+def _find_merged_child(
+    conn: sqlite3.Connection, parent_id: int, config: LLMConfig
+) -> int | None:
+    """Return an existing merged child's run id for this parent + LLM, if any."""
+    row = conn.execute(
+        "SELECT cluster_run_id FROM cluster_runs "
+        "WHERE method = 'merged' "
+        "AND json_extract(params_json, '$.parent_cluster_run_id') = ? "
+        "AND json_extract(params_json, '$.provider') = ? "
+        "AND json_extract(params_json, '$.model') = ? "
+        "ORDER BY cluster_run_id DESC LIMIT 1",
+        (parent_id, config.provider.value, config.model),
+    ).fetchone()
+    return row["cluster_run_id"] if row else None
+
+
+def _gather_clusters(
+    conn: sqlite3.Connection, cluster_run_id: int
+) -> list[dict]:
+    """Gather (cluster_id, size, label, rationale, keywords) for non-noise clusters.
+
+    Uses the latest summary per cluster (max cluster_summary_id).
+    """
+    rows = conn.execute(
+        """
+        SELECT ca.cluster_id, COUNT(*) AS size, cs.label, cs.label_json
+        FROM cluster_assignments ca
+        JOIN cluster_summaries cs
+          ON cs.cluster_run_id = ca.cluster_run_id AND cs.cluster_id = ca.cluster_id
+        WHERE ca.cluster_run_id = ? AND ca.cluster_id >= 0
+          AND cs.cluster_summary_id = (
+              SELECT MAX(cs2.cluster_summary_id) FROM cluster_summaries cs2
+              WHERE cs2.cluster_run_id = ca.cluster_run_id AND cs2.cluster_id = ca.cluster_id
+          )
+        GROUP BY ca.cluster_id, cs.label, cs.label_json
+        ORDER BY ca.cluster_id
+        """,
+        (cluster_run_id,),
+    ).fetchall()
+
+    clusters = []
+    for r in rows:
+        label_data = json.loads(r["label_json"])
+        clusters.append({
+            "cluster_id": r["cluster_id"],
+            "size": r["size"],
+            "label": r["label"],
+            "rationale": label_data.get("rationale", ""),
+            "keywords": label_data.get("keywords", []),
+        })
+    return clusters
+
+
+def _format_clusters(clusters: list[dict]) -> str:
+    lines = []
+    for c in clusters:
+        keywords = ", ".join(c["keywords"])
+        lines.append(
+            f"- Cluster {c['cluster_id']} (size {c['size']}): {c['label']}\n"
+            f"    rationale: {c['rationale']}\n"
+            f"    keywords: {keywords}"
+        )
+    return "\n".join(lines)
+
+
+def _sanitize_merges(
+    merges: list[MergeGroup], valid_ids: list[int]
+) -> list[tuple[list[int], str]]:
+    """Filter LLM-proposed merge groups against the guardrails.
+
+    - Drop ids that are noise/unknown (not in valid_ids).
+    - A cluster may appear in at most one group (first occurrence wins).
+    - Drop groups left with fewer than 2 ids.
+    - Never collapse below _MIN_RESULTING_CLUSTERS resulting clusters: drop
+      groups (largest first) until the floor is satisfied.
+
+    Returns (sorted cluster-id group, rationale) pairs — the rationale is
+    carried through so the audit trail stays correct even when sanitizing
+    strips ids from a group.
+    """
+    valid = set(valid_ids)
+    seen: set[int] = set()
+    groups: list[tuple[list[int], str]] = []
+    for group in merges:
+        ids = []
+        for cid in group.cluster_ids:
+            if cid in valid and cid not in seen:
+                ids.append(cid)
+                seen.add(cid)
+        if len(ids) >= 2:
+            groups.append((sorted(ids), group.rationale))
+
+    # Enforce the resulting-cluster floor, dropping the most aggressive groups
+    # first so we keep as many of the smaller, safer merges as possible.
+    def _resulting_count(gs: list[tuple[list[int], str]]) -> int:
+        return len(valid_ids) - sum(len(ids) - 1 for ids, _ in gs)
+
+    groups.sort(key=lambda g: len(g[0]), reverse=True)
+    while groups and _resulting_count(groups) < _MIN_RESULTING_CLUSTERS:
+        groups.pop(0)
+
+    return groups
+
+
+def _build_id_map(valid_ids: list[int], groups: list[list[int]]) -> dict[int, int]:
+    """Map old non-noise cluster ids to contiguous new ids starting at 0.
+
+    Each merge group collapses to one new id anchored at its smallest member;
+    non-merged ids keep their own slot. Iteration is ascending for determinism.
+    """
+    representative: dict[int, int] = {}
+    for group in groups:
+        anchor = min(group)
+        for cid in group:
+            representative[cid] = anchor
+
+    old_to_new: dict[int, int] = {}
+    next_new = 0
+    for old in sorted(valid_ids):
+        rep = representative.get(old, old)
+        if rep not in old_to_new:
+            old_to_new[rep] = next_new
+            next_new += 1
+        if old != rep:
+            old_to_new[old] = old_to_new[rep]
+    return old_to_new
+
+
+def merge_clusters(
+    conn: sqlite3.Connection,
+    cluster_run_id: int,
+    config: LLMConfig,
+    job_id: int | None = None,
+    force: bool = False,
+) -> dict:
+    """Auto-merge clusters of a labeled run into a new derived 'merged' run.
+
+    Idempotent — unless ``force`` is set, returns an existing merged child for
+    this parent + LLM instead of making a new one. Returns a summary dict.
+    """
+    run = _get_run(conn, cluster_run_id)
+    if run is None:
+        raise ValueError(f"Cluster run {cluster_run_id} not found.")
+
+    if not force:
+        existing = _find_merged_child(conn, cluster_run_id, config)
+        if existing is not None:
+            return {"merged": False, "skipped": True, "cluster_run_id": existing}
+
+    clusters = _gather_clusters(conn, cluster_run_id)
+    if not clusters:
+        raise ValueError(
+            f"Cluster run {cluster_run_id} has no cluster summaries; "
+            "run labeling first."
+        )
+
+    valid_ids = [c["cluster_id"] for c in clusters]
+
+    decision = generate_json(
+        task_name="merge_clusters",
+        schema_model=MergeDecision,
+        prompt=_PROMPT_TEMPLATE.format(clusters=_format_clusters(clusters)),
+        inputs={"cluster_run_id": cluster_run_id, "cluster_ids": valid_ids},
+        config=config,
+        conn=conn,
+        job_id=job_id,
+    )
+
+    groups = _sanitize_merges(decision.merges, valid_ids)
+    if not groups:
+        return {"merged": False, "skipped": True, "reason": "no valid merges"}
+
+    old_to_new = _build_id_map(valid_ids, [ids for ids, _ in groups])
+
+    # Record applied merges with their resulting (new) cluster id for auditing.
+    # ids is sorted ascending, so ids[0] is the group's anchor (its new id).
+    applied = [
+        {
+            "new_cluster_id": old_to_new[ids[0]],
+            "source_cluster_ids": ids,
+            "rationale": rationale,
+        }
+        for ids, rationale in groups
+    ]
+
+    params = {
+        "parent_cluster_run_id": cluster_run_id,
+        "merges": applied,
+        "provider": config.provider.value,
+        "model": config.model,
+    }
+    cursor = conn.execute(
+        "INSERT INTO cluster_runs (reduction_id, method, params_json) "
+        "VALUES (?, 'merged', ?)",
+        (run["reduction_id"], json.dumps(params, sort_keys=True)),
+    )
+    new_run_id = cursor.lastrowid
+
+    source_assignments = conn.execute(
+        "SELECT item_id, cluster_id, membership_probability "
+        "FROM cluster_assignments WHERE cluster_run_id = ?",
+        (cluster_run_id,),
+    ).fetchall()
+    conn.executemany(
+        "INSERT INTO cluster_assignments "
+        "(cluster_run_id, item_id, cluster_id, membership_probability) "
+        "VALUES (?, ?, ?, ?)",
+        [
+            (
+                new_run_id,
+                a["item_id"],
+                old_to_new[a["cluster_id"]] if a["cluster_id"] >= 0 else -1,
+                a["membership_probability"],
+            )
+            for a in source_assignments
+        ],
+    )
+    conn.commit()
+
+    # Fresh exemplars + labels for the renumbered clusters.
+    select_exemplars(conn, new_run_id)
+    label_clusters(conn, new_run_id, config, job_id=job_id)
+
+    return {
+        "merged": True,
+        "skipped": False,
+        "cluster_run_id": new_run_id,
+        "merges": applied,
+        "n_clusters_before": len(valid_ids),
+        "n_clusters_after": len(set(old_to_new.values())),
+    }

--- a/fluster/server.py
+++ b/fluster/server.py
@@ -8,9 +8,12 @@ from fastapi import APIRouter, Depends, FastAPI, HTTPException, Request
 from pydantic import BaseModel, Field
 
 from fluster import __version__
+from fluster.config import settings
+from fluster.config.plan import load_plan
 from fluster.config.project import project_dir, project_exists
 from fluster.db.connection import connect
 from fluster.jobs.manager import create_job, get_active_job, get_job, request_cancel
+from fluster.pipeline.merge import merge_clusters
 
 # ---------------------------------------------------------------------------
 # Pydantic models
@@ -81,6 +84,14 @@ class ClusterRunDetail(BaseModel):
     assignments: list[ClusterAssignment]
     labels: list[ClusterSummary]
     critique: dict | None = None
+
+
+class MergeResponse(BaseModel):
+    cluster_run_id: int | None  # the merged run (existing or new); None if nothing merged
+    parent_cluster_run_id: int
+    merges: list[dict] = Field(default_factory=list)
+    skipped: bool
+    reason: str | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -262,6 +273,27 @@ def get_cluster_run(
         assignments=assignments,
         labels=labels,
         critique=critique,
+    )
+
+
+@router.post("/cluster-runs/{cluster_run_id}/merge")
+def merge_cluster_run(
+    cluster_run_id: int,
+    request: Request,
+    conn: sqlite3.Connection = Depends(get_conn),
+) -> MergeResponse:
+    plan = load_plan(request.app.state.project_dir / settings.PLAN_YAML)
+    try:
+        summary = merge_clusters(conn, cluster_run_id, plan.llm)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+    return MergeResponse(
+        cluster_run_id=summary.get("cluster_run_id"),
+        parent_cluster_run_id=cluster_run_id,
+        merges=summary.get("merges", []),
+        skipped=summary["skipped"],
+        reason=summary.get("reason"),
     )
 
 

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -1,0 +1,273 @@
+"""Tests for merge_clusters (issue #1 — automatic LLM cluster merging)."""
+
+import json
+from unittest.mock import patch
+
+from fluster.config.plan import LLMConfig, LLMProvider, Plan
+from fluster.pipeline.embed import embed_items
+from fluster.pipeline.ingest import ingest_rows
+from fluster.pipeline.materialize import materialize_items
+from fluster.pipeline.merge import (
+    MergeGroup,
+    _build_id_map,
+    _sanitize_merges,
+    merge_clusters,
+)
+from fluster.pipeline.reduce import reduce_items
+
+
+# --- Pure logic: guardrails (_sanitize_merges) ---
+
+def _g(*ids, rationale="x"):
+    return MergeGroup(cluster_ids=list(ids), rationale=rationale)
+
+
+def test_sanitize_drops_noise_and_unknown():
+    # -1 (noise) and 99 (unknown) are dropped; the lone survivor leaves <2 -> group dropped.
+    groups = _sanitize_merges([_g(0, -1, 99)], valid_ids=[0, 1, 2, 3])
+    assert groups == []
+
+
+def test_sanitize_drops_single_id_group():
+    assert _sanitize_merges([_g(1)], valid_ids=[0, 1, 2, 3]) == []
+
+
+def test_sanitize_dedupes_across_groups():
+    # 1 appears twice; first group keeps it, second is left with only [2] and dropped.
+    groups = _sanitize_merges([_g(0, 1), _g(1, 2)], valid_ids=[0, 1, 2, 3])
+    assert groups == [([0, 1], "x")]
+
+
+def test_sanitize_floor_refuses_collapsing_everything():
+    # Merging all 4 clusters would yield 1 resulting cluster (< floor of 2) -> dropped.
+    assert _sanitize_merges([_g(0, 1, 2, 3)], valid_ids=[0, 1, 2, 3]) == []
+
+
+def test_sanitize_keeps_valid_merge():
+    assert _sanitize_merges([_g(2, 0)], valid_ids=[0, 1, 2, 3]) == [([0, 2], "x")]
+
+
+def test_sanitize_carries_rationale_through_stripping():
+    # 99 is stripped but the rationale must survive on the sanitized group.
+    groups = _sanitize_merges([_g(0, 2, 99, rationale="dupes")], valid_ids=[0, 1, 2, 3])
+    assert groups == [([0, 2], "dupes")]
+
+
+# --- Pure logic: id remapping (_build_id_map) ---
+
+def test_build_id_map_contiguous_without_merges():
+    assert _build_id_map([0, 1, 2], groups=[]) == {0: 0, 1: 1, 2: 2}
+
+
+def test_build_id_map_collapses_group_at_smallest_member():
+    # Merge {0,2}; ids stay contiguous from 0, anchored at the group's min.
+    assert _build_id_map([0, 1, 2, 3], groups=[[0, 2]]) == {0: 0, 1: 1, 2: 0, 3: 2}
+
+
+# --- Integration helpers ---
+
+def _write_csv(path, header, *rows):
+    csv_file = path / "data.csv"
+    csv_file.write_text("\n".join([header] + list(rows)) + "\n")
+    return csv_file
+
+
+def _llm_config():
+    return LLMConfig(provider=LLMProvider.openai, model="gpt-5-mini")
+
+
+def _label_response():
+    return json.dumps({
+        "label": "Some Topic",
+        "short_label": "Topic",
+        "rationale": "Items share a theme.",
+        "keywords": ["alpha", "beta"],
+    })
+
+
+def _responder(decision):
+    """side_effect: decision JSON for the merge prompt, label JSON otherwise."""
+    def _fn(prompt, config):
+        if '"merges"' in prompt:
+            return json.dumps(decision)
+        return _label_response()
+    return _fn
+
+
+# Source layout: clusters 0-3 with 5/5/5/4 members, item 19 is noise (-1).
+_SOURCE_CLUSTERS = {0: range(0, 5), 1: range(5, 10), 2: range(10, 15), 3: range(15, 19)}
+_NOISE_ITEM = 19
+_SOURCE_COUNT = 20
+
+
+def _setup_source_run(pdir, conn):
+    """Embed/reduce real items, then insert a synthetic labeled source run."""
+    for i in range(_SOURCE_COUNT):
+        (pdir / f"item{i}.txt").write_text(
+            f"Item {i} about {'science' if i % 2 == 0 else 'art'} topic {i}."
+        )
+    rows = [f"item{i},{pdir}/item{i}.txt" for i in range(_SOURCE_COUNT)]
+    ingest_rows(conn, _write_csv(pdir, "name,file_path", *rows), pdir)
+    materialize_items(conn, pdir)
+    plan = Plan()
+    embed_items(conn, plan)
+    reduce_items(conn, plan)
+
+    reduction_id = conn.execute("SELECT reduction_id FROM reductions LIMIT 1").fetchone()[0]
+    item_ids = [r["item_id"] for r in conn.execute("SELECT item_id FROM items ORDER BY item_id")]
+
+    cursor = conn.execute(
+        "INSERT INTO cluster_runs (reduction_id, method, params_json) VALUES (?, 'hdbscan', '{}')",
+        (reduction_id,),
+    )
+    run_id = cursor.lastrowid
+
+    cluster_of = {}
+    for cid, members in _SOURCE_CLUSTERS.items():
+        for m in members:
+            cluster_of[m] = cid
+    cluster_of[_NOISE_ITEM] = -1
+
+    conn.executemany(
+        "INSERT INTO cluster_assignments (cluster_run_id, item_id, cluster_id, membership_probability) "
+        "VALUES (?, ?, ?, 1.0)",
+        [(run_id, item_ids[i], cluster_of[i]) for i in range(_SOURCE_COUNT)],
+    )
+    for cid in _SOURCE_CLUSTERS:
+        conn.execute(
+            "INSERT INTO cluster_summaries "
+            "(cluster_run_id, cluster_id, provider, model, label, label_json) "
+            "VALUES (?, ?, 'openai', 'gpt-5-mini', ?, ?)",
+            (run_id, cid, f"Cluster {cid}",
+             json.dumps({"rationale": f"about topic {cid}", "keywords": [f"k{cid}"]})),
+        )
+    conn.commit()
+    return run_id
+
+
+# --- Integration: end-to-end merge ---
+
+@patch("fluster.llm.client._call_openai")
+def test_merge_creates_run_with_fresh_summaries(mock_call, project):
+    pdir, conn = project
+    run_id = _setup_source_run(pdir, conn)
+    mock_call.side_effect = _responder({"merges": [{"cluster_ids": [0, 2], "rationale": "same"}]})
+
+    summary = merge_clusters(conn, run_id, _llm_config())
+
+    assert summary["merged"] is True
+    new_id = summary["cluster_run_id"]
+
+    run = conn.execute("SELECT * FROM cluster_runs WHERE cluster_run_id = ?", (new_id,)).fetchone()
+    assert run["method"] == "merged"
+    params = json.loads(run["params_json"])
+    assert params["parent_cluster_run_id"] == run_id  # parent linkage
+
+    # Fresh exemplars + summaries exist for every merged cluster.
+    n_clusters = summary["n_clusters_after"]
+    summ = conn.execute(
+        "SELECT COUNT(DISTINCT cluster_id) AS n FROM cluster_summaries WHERE cluster_run_id = ?",
+        (new_id,),
+    ).fetchone()["n"]
+    exem = conn.execute(
+        "SELECT COUNT(DISTINCT cluster_id) AS n FROM cluster_exemplars WHERE cluster_run_id = ?",
+        (new_id,),
+    ).fetchone()["n"]
+    assert summ == n_clusters
+    assert exem == n_clusters
+
+
+@patch("fluster.llm.client._call_openai")
+def test_merge_rewrites_assignments_and_carries_noise(mock_call, project):
+    pdir, conn = project
+    run_id = _setup_source_run(pdir, conn)
+    mock_call.side_effect = _responder({"merges": [{"cluster_ids": [0, 2], "rationale": "same"}]})
+
+    new_id = merge_clusters(conn, run_id, _llm_config())["cluster_run_id"]
+
+    counts = dict(conn.execute(
+        "SELECT cluster_id, COUNT(*) FROM cluster_assignments WHERE cluster_run_id = ? GROUP BY cluster_id",
+        (new_id,),
+    ).fetchall())
+    # 0 and 2 fold into new cluster 0 (5+5); old 1 -> 1; old 3 -> 2; noise stays -1.
+    assert counts == {0: 10, 1: 5, 2: 4, -1: 1}
+
+
+@patch("fluster.llm.client._call_openai")
+def test_merge_is_idempotent(mock_call, project):
+    pdir, conn = project
+    run_id = _setup_source_run(pdir, conn)
+    mock_call.side_effect = _responder({"merges": [{"cluster_ids": [0, 2], "rationale": "same"}]})
+
+    first = merge_clusters(conn, run_id, _llm_config())
+    calls_after_first = mock_call.call_count
+
+    second = merge_clusters(conn, run_id, _llm_config())
+    assert second["skipped"] is True
+    assert second["cluster_run_id"] == first["cluster_run_id"]
+    assert mock_call.call_count == calls_after_first  # no LLM call on the skip
+
+    forced = merge_clusters(conn, run_id, _llm_config(), force=True)
+    assert forced["merged"] is True
+    assert forced["cluster_run_id"] != first["cluster_run_id"]
+
+
+@patch("fluster.llm.client._call_openai")
+def test_merge_refusing_all_collapse_creates_no_run(mock_call, project):
+    pdir, conn = project
+    run_id = _setup_source_run(pdir, conn)
+    mock_call.side_effect = _responder({"merges": [{"cluster_ids": [0, 1, 2, 3], "rationale": "all"}]})
+
+    summary = merge_clusters(conn, run_id, _llm_config())
+    assert summary["skipped"] is True
+    assert summary.get("reason") == "no valid merges"
+    merged = conn.execute("SELECT COUNT(*) FROM cluster_runs WHERE method = 'merged'").fetchone()[0]
+    assert merged == 0
+
+
+@patch("fluster.llm.client._call_openai")
+def test_merge_records_rationale_after_stripping(mock_call, project):
+    # The LLM proposes an unknown id (99) that gets stripped; the recorded
+    # applied-merge rationale must still be preserved (audit-trail regression).
+    pdir, conn = project
+    run_id = _setup_source_run(pdir, conn)
+    mock_call.side_effect = _responder(
+        {"merges": [{"cluster_ids": [0, 2, 99], "rationale": "clearly duplicates"}]}
+    )
+
+    new_id = merge_clusters(conn, run_id, _llm_config())["cluster_run_id"]
+
+    params = json.loads(conn.execute(
+        "SELECT params_json FROM cluster_runs WHERE cluster_run_id = ?", (new_id,)
+    ).fetchone()["params_json"])
+    assert params["merges"][0]["source_cluster_ids"] == [0, 2]
+    assert params["merges"][0]["rationale"] == "clearly duplicates"
+
+
+@patch("fluster.llm.client._call_openai")
+def test_merge_logs_llm_call(mock_call, project):
+    pdir, conn = project
+    run_id = _setup_source_run(pdir, conn)
+    mock_call.side_effect = _responder({"merges": [{"cluster_ids": [0, 2], "rationale": "same"}]})
+
+    merge_clusters(conn, run_id, _llm_config())
+
+    logs = conn.execute(
+        "SELECT * FROM llm_calls WHERE task_name = 'merge_clusters'"
+    ).fetchall()
+    assert len(logs) == 1
+    assert logs[0]["provider"] == "openai"
+
+
+def test_merge_without_summaries_raises(project):
+    import pytest
+    pdir, conn = project
+    # A run with assignments but no summaries.
+    conn.execute("INSERT INTO reductions (embedding_reference, method, target_dimensions) VALUES ('e', 'umap', 8)")
+    rid = conn.execute("SELECT reduction_id FROM reductions LIMIT 1").fetchone()[0]
+    conn.execute("INSERT INTO cluster_runs (reduction_id, method, params_json) VALUES (?, 'hdbscan', '{}')", (rid,))
+    run_id = conn.execute("SELECT cluster_run_id FROM cluster_runs LIMIT 1").fetchone()[0]
+    conn.commit()
+
+    with pytest.raises(ValueError, match="no cluster summaries"):
+        merge_clusters(conn, run_id, _llm_config())


### PR DESCRIPTION
## Summary

Adds a **fully automatic LLM merge** step for over-segmented clustering runs. Given a finished, labeled cluster run, an LLM reads every non-noise cluster's label + rationale + keywords + size and decides which clusters describe the same underlying concept. The merges are applied into a **new derived `cluster_runs` row** (`method = "merged"`) — the source run is never mutated, so merges are non-destructive and stackable.

Because a merged run copies the parent's `reduction_id`, **every downstream consumer works with no special-casing** (exemplars, labeling, critique, export, server) and **no schema change** is needed — the parent link + applied merge groups live in `cluster_runs.params_json`.

## What's included

- **`fluster/pipeline/merge.py`** (new) — `merge_clusters(conn, cluster_run_id, config, job_id=None, force=False)`. Gathers the source run's latest summaries, makes one merge-decision LLM call (`task_name="merge_clusters"`, logged to `llm_calls`), sanitizes the result, rewrites assignments into a renumbered run, and re-runs exemplars + labeling.
- **`fluster merge --cluster-run <id> [--force]`** CLI command.
- **`POST /cluster-runs/{id}/merge`** endpoint + `MergeResponse` model.
- **README** snippet.
- **`tests/test_merge.py`** (new) — 15 tests.

## Design decisions (confirmed with maintainer)

- **Parent linkage** → `params_json` (no schema migration; works on existing DBs).
- **Idempotency** → skips and returns an existing merged child for the same parent/provider/model; `--force` (CLI) creates a fresh one.
- **Guardrails** → never collapses below 2 resulting clusters; drops merge groups referencing noise/unknown/duplicate or fewer-than-2 ids; the prompt asks the LLM to be conservative.
- **Noise** (`cluster_id = -1`) → always carried over, never a merge target.
- **Scope** → CLI + endpoint + pipeline + tests. The Svelte "merge & reload" button is left to a follow-up. (The HTTP endpoint is idempotent with no `--force`; a force query-param could be a later addition.)

## Testing

- `tests/test_merge.py`: pure-logic guardrail/remap unit tests + integration tests (decision parsing, assignment rewrite **with noise carry-over**, idempotency + `--force`, floor refusal, parent linkage, fresh summaries, `llm_calls` audit, rationale survival after id stripping).
- Full suite: **225 passing**.

## Acceptance criteria

- [x] `fluster merge --cluster-run <id>` produces a new `merged` run without altering the source.
- [x] Merged run has fresh exemplars + summaries for all clusters.
- [x] `POST /cluster-runs/{id}/merge` returns the new run id + applied merges.
- [x] Merge LLM call recorded in `llm_calls`.
- [x] Exports + web view work against the merged run with no special-casing (copied `reduction_id`).
- [x] Tests cover decision parsing, assignment rewrite (incl. noise carry-over), and idempotency.

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)