### PR TITLE
Add a SOM grid visualization via minisom (reduction + codebook clustering)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 - Materialize rows into structured items
 - Extract and normalize text
 - Generate embeddings
-- Reduce dimensions (PCA + UMAP)
-- Cluster (HDBSCAN or agglomerative)
+- Reduce dimensions (PCA + UMAP, or a SOM grid)
+- Cluster (HDBSCAN or agglomerative — on coordinates or a SOM codebook)
 - Select representative exemplars per cluster
 - Label clusters with an LLM (BYO)
 - Critique the clustering run
@@ -133,6 +133,46 @@ fluster cancel 1 --force
 fluster list
 fluster use other-project
 ```
+
+---
+
+## SOM grid view (optional)
+
+Points-on-a-plane (UMAP) is the default way to look at a run. If you'd rather see
+your data laid out on a tidy grid, `fluster` can also train a [self-organizing
+map](https://en.wikipedia.org/wiki/Self-organizing_map) (SOM). It's **opt-in** —
+nothing changes unless you ask for it — so add it to your `plan.yaml` with
+`fluster plan`:
+
+```yaml
+reductions:
+  - method: pca
+    target_dimensions: 50
+  - method: umap
+    target_dimensions: 2
+  - method: umap
+    target_dimensions: 8
+  - method: som          # the new bit — trains a grid (grid_x/grid_y auto-size if omitted)
+
+clustering:
+  - method: hdbscan      # your usual run, on the umap_8d coordinates
+    reduction: umap_8d
+    params: { min_cluster_size: 5 }
+  - method: agglomerative # a two-level SOM: cluster the grid's codebook...
+    reduction: som_2d
+    target: codebook      # ...and hand each item the cluster of its grid cell
+    params: { n_clusters: 8 }
+```
+
+Run `fluster run` as usual, then `fluster chill`. On a run's page you'll get a
+**UMAP / SOM grid** toggle: the grid shades each cell by its U-matrix distance
+(how far it sits from its neighbors), tints it by the cluster living there, and
+darkens it by how many items landed in it. Click a cell to inspect what's inside.
+
+A SOM is just another reduction with receipts, so it's stored, versioned, and
+seed-fixed like everything else. (Heads up: it's a new table, so a project made
+before SOM support won't grow one retroactively — `fluster init` a fresh one to
+play with it.)
 
 ---
 

--- a/client/drizzle.config.ts
+++ b/client/drizzle.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
 		'embeddings',
 		'reductions',
 		'reduction_coordinates',
+		'som_nodes',
 		'cluster_runs',
 		'cluster_assignments',
 		'cluster_exemplars',

--- a/client/src/lib/components/SomGrid.svelte
+++ b/client/src/lib/components/SomGrid.svelte
@@ -1,0 +1,267 @@
+<script lang="ts">
+	type Point = {
+		itemId: number;
+		x: number; // grid row (grid_i)
+		y: number; // grid col (grid_j)
+		clusterId: number;
+		recordName: string;
+		embeddingText: string;
+		metadata: Record<string, unknown>;
+		imageArtifactId: string | null;
+	};
+
+	type SomGridData = {
+		gridX: number;
+		gridY: number;
+		nodes: { i: number; j: number; umatrixDist: number }[];
+	};
+
+	interface Props {
+		points: Point[];
+		somGrid: SomGridData;
+		getColor: (clusterId: number) => string;
+		focusClusterId?: number | null;
+		onSelect?: (itemId: number) => void;
+	}
+
+	let { points, somGrid, getColor, focusClusterId = null, onSelect }: Props = $props();
+
+	type Cell = {
+		i: number;
+		j: number;
+		items: Point[];
+		dominantCluster: number | null;
+		umatrixDist: number;
+	};
+
+	const cellKey = (i: number, j: number) => `${i},${j}`;
+
+	// One cell per grid node, in row-major (i outer, j inner) order so the CSS
+	// grid auto-places them left-to-right, top-to-bottom.
+	const cells = $derived.by(() => {
+		const umatrix = new Map<string, number>();
+		for (const n of somGrid.nodes) umatrix.set(cellKey(n.i, n.j), n.umatrixDist);
+
+		const bucket = new Map<string, Point[]>();
+		for (const p of points) {
+			const k = cellKey(p.x, p.y);
+			let arr = bucket.get(k);
+			if (!arr) bucket.set(k, (arr = []));
+			arr.push(p);
+		}
+
+		const out: Cell[] = [];
+		for (let i = 0; i < somGrid.gridX; i++) {
+			for (let j = 0; j < somGrid.gridY; j++) {
+				const items = bucket.get(cellKey(i, j)) ?? [];
+				out.push({
+					i,
+					j,
+					items,
+					dominantCluster: dominantCluster(items),
+					umatrixDist: umatrix.get(cellKey(i, j)) ?? 0
+				});
+			}
+		}
+		return out;
+	});
+
+	const maxCount = $derived(cells.reduce((m, c) => Math.max(m, c.items.length), 0));
+
+	function dominantCluster(items: Point[]): number | null {
+		if (items.length === 0) return null;
+		const counts = new Map<number, number>();
+		for (const p of items) counts.set(p.clusterId, (counts.get(p.clusterId) ?? 0) + 1);
+		let best = items[0].clusterId;
+		let bestN = -1;
+		for (const [id, n] of counts) {
+			if (n > bestN) {
+				bestN = n;
+				best = id;
+			}
+		}
+		return best;
+	}
+
+	function cellMatchesFocus(cell: Cell): boolean {
+		if (focusClusterId == null) return true;
+		return cell.items.some((p) => p.clusterId === focusClusterId);
+	}
+
+	function cellFill(cell: Cell): string {
+		if (cell.dominantCluster == null) return 'transparent';
+		const intensity = maxCount > 0 ? 0.35 + 0.65 * (cell.items.length / maxCount) : 0;
+		const color = getColor(cell.dominantCluster);
+		return mixWithAlpha(color, intensity);
+	}
+
+	// A hex color at a given alpha, as rgba().
+	function mixWithAlpha(hex: string, alpha: number): string {
+		const m = /^#?([0-9a-f]{6})$/i.exec(hex.trim());
+		if (!m) return hex;
+		const n = parseInt(m[1], 16);
+		const r = (n >> 16) & 255;
+		const g = (n >> 8) & 255;
+		const b = n & 255;
+		return `rgba(${r}, ${g}, ${b}, ${alpha.toFixed(3)})`;
+	}
+
+	// --- Interaction ---
+	let hovered: Cell | null = $state(null);
+	let tooltipX = $state(0);
+	let tooltipY = $state(0);
+	let selectedKey: string | null = $state(null);
+	let container: HTMLDivElement | undefined = $state();
+
+	function handleEnter(cell: Cell, e: MouseEvent) {
+		hovered = cell;
+		moveTooltip(e);
+	}
+
+	function moveTooltip(e: MouseEvent) {
+		if (!container) return;
+		const rect = container.getBoundingClientRect();
+		tooltipX = e.clientX - rect.left;
+		tooltipY = e.clientY - rect.top;
+	}
+
+	function handleClick(cell: Cell) {
+		if (cell.items.length === 0) {
+			selectedKey = null;
+			return;
+		}
+		selectedKey = cellKey(cell.i, cell.j);
+		onSelect?.(cell.items[0].itemId);
+	}
+</script>
+
+<div class="som-wrap" bind:this={container}>
+	<div
+		class="grid"
+		style="grid-template-columns: repeat({somGrid.gridY}, 1fr); grid-template-rows: repeat({somGrid.gridX}, 1fr); aspect-ratio: {somGrid.gridY} / {somGrid.gridX};"
+		role="presentation"
+		onmouseleave={() => (hovered = null)}
+	>
+		{#each cells as cell (cellKey(cell.i, cell.j))}
+			<button
+				type="button"
+				class="cell"
+				class:faded={!cellMatchesFocus(cell)}
+				class:selected={selectedKey === cellKey(cell.i, cell.j)}
+				class:empty={cell.items.length === 0}
+				style="background:
+					linear-gradient(rgba(255,255,255,{(cell.umatrixDist * 0.12).toFixed(3)}), rgba(255,255,255,{(cell.umatrixDist * 0.12).toFixed(3)})),
+					{cellFill(cell)};"
+				aria-label="cell {cell.i},{cell.j}, {cell.items.length} items"
+				onmouseenter={(e) => handleEnter(cell, e)}
+				onmousemove={moveTooltip}
+				onclick={() => handleClick(cell)}
+			></button>
+		{/each}
+	</div>
+
+	{#if hovered}
+		<div class="tooltip" style="left: {tooltipX + 12}px; top: {tooltipY - 12}px;">
+			<div class="tooltip-head">cell {hovered.i},{hovered.j}</div>
+			{#if hovered.items.length === 0}
+				<div class="muted">empty</div>
+			{:else}
+				<div>{hovered.items.length} item{hovered.items.length === 1 ? '' : 's'}</div>
+				{#if hovered.dominantCluster != null}
+					<div class="tooltip-cluster muted">
+						<span class="swatch" style="background: {getColor(hovered.dominantCluster)}"></span>
+						cluster {hovered.dominantCluster}
+					</div>
+				{/if}
+				{#if hovered.items.length === 1}
+					<div class="tooltip-name">{hovered.items[0].recordName || 'unnamed'}</div>
+				{/if}
+			{/if}
+		</div>
+	{/if}
+</div>
+
+<style>
+	.som-wrap {
+		position: absolute;
+		inset: 0;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		padding: 2rem;
+		background: var(--color-bg);
+	}
+
+	.grid {
+		display: grid;
+		gap: 1px;
+		max-width: 100%;
+		max-height: 100%;
+		width: auto;
+		height: 100%;
+	}
+
+	.cell {
+		padding: 0;
+		margin: 0;
+		border: 1px solid rgba(255, 255, 255, 0.06);
+		border-radius: 0;
+		cursor: pointer;
+		transition: opacity 0.1s;
+		min-width: 0;
+		min-height: 0;
+	}
+
+	.cell.empty {
+		cursor: default;
+	}
+
+	.cell.faded {
+		opacity: 0.15;
+	}
+
+	.cell:hover {
+		outline: 1px solid var(--color-fg);
+		outline-offset: -1px;
+	}
+
+	.cell.selected {
+		outline: 2px solid var(--color-fg);
+		outline-offset: -2px;
+	}
+
+	.tooltip {
+		position: absolute;
+		background: var(--color-bg-secondary);
+		color: var(--color-fg);
+		padding: 0.5rem;
+		font-size: 0.75rem;
+		max-width: 16rem;
+		pointer-events: none;
+		z-index: 10;
+		line-height: 1.5;
+	}
+
+	.tooltip-head {
+		font-weight: 600;
+	}
+
+	.tooltip-name {
+		word-break: break-word;
+		margin-top: 0.25rem;
+	}
+
+	.tooltip-cluster {
+		display: flex;
+		align-items: center;
+		gap: 0.375rem;
+		font-size: 0.6875rem;
+	}
+
+	.swatch {
+		display: inline-block;
+		width: 0.625rem;
+		height: 0.625rem;
+		border-radius: 2px;
+	}
+</style>

--- a/client/src/lib/server/db/schema.ts
+++ b/client/src/lib/server/db/schema.ts
@@ -94,6 +94,17 @@ export const reductionCoordinates = sqliteTable("reduction_coordinates", {
 	primaryKey({ columns: [table.reductionId, table.itemId], name: "reduction_coordinates_reduction_id_item_id_pk"}),
 ]);
 
+export const somNodes = sqliteTable("som_nodes", {
+	reductionId: integer("reduction_id").notNull().references(() => reductions.reductionId),
+	nodeIndex: integer("node_index").notNull(),
+	gridI: integer("grid_i").notNull(),
+	gridJ: integer("grid_j").notNull(),
+	weightJson: text("weight_json").notNull(),
+	umatrixDist: real("umatrix_dist").notNull(),
+}, (table) => [
+	primaryKey({ columns: [table.reductionId, table.nodeIndex], name: "som_nodes_reduction_id_node_index_pk"}),
+]);
+
 export const clusterRuns = sqliteTable("cluster_runs", {
 	clusterRunId: integer("cluster_run_id").primaryKey({ autoIncrement: true }),
 	reductionId: integer("reduction_id").notNull().references(() => reductions.reductionId),

--- a/client/src/lib/server/queries/items.ts
+++ b/client/src/lib/server/queries/items.ts
@@ -6,6 +6,7 @@ import {
 	representations,
 	reductions,
 	reductionCoordinates,
+	somNodes,
 	clusterAssignments,
 	clusterRuns,
 	itemArtifacts,
@@ -162,6 +163,43 @@ export function getLayoutData(clusterRunId: number, reductionId: number) {
 			imageArtifactId: imageMap.get(r.itemId) ?? null
 		};
 	});
+}
+
+export type SomGrid = {
+	gridX: number;
+	gridY: number;
+	nodes: { i: number; j: number; umatrixDist: number }[];
+};
+
+/** Grid dimensions + per-node U-matrix distances for a SOM reduction, or null
+ * if the reduction is not a SOM. Used to draw the grid background. */
+export function getSomGrid(reductionId: number): SomGrid | null {
+	const reduction = db
+		.select({ method: reductions.method, paramsJson: reductions.paramsJson })
+		.from(reductions)
+		.where(eq(reductions.reductionId, reductionId))
+		.get();
+
+	if (!reduction || reduction.method !== 'som') return null;
+
+	let params: { grid_x?: number; grid_y?: number } = {};
+	try {
+		params = JSON.parse(reduction.paramsJson);
+	} catch {}
+	if (params.grid_x == null || params.grid_y == null) return null;
+
+	const nodes = db
+		.select({
+			i: somNodes.gridI,
+			j: somNodes.gridJ,
+			umatrixDist: somNodes.umatrixDist
+		})
+		.from(somNodes)
+		.where(eq(somNodes.reductionId, reductionId))
+		.orderBy(somNodes.nodeIndex)
+		.all();
+
+	return { gridX: params.grid_x, gridY: params.grid_y, nodes };
 }
 
 export function getItemDetail(itemId: number) {

--- a/client/src/lib/server/queries/items.ts
+++ b/client/src/lib/server/queries/items.ts
@@ -4,6 +4,7 @@ import {
 	items,
 	rows,
 	representations,
+	reductions,
 	reductionCoordinates,
 	clusterAssignments,
 	clusterRuns,
@@ -37,15 +38,77 @@ function getImageArtifactIds(itemIds: number[]): Map<number, string> {
 	return map;
 }
 
-export function getScatterPlotData(clusterRunId: number) {
+export type Layout = {
+	reductionId: number;
+	method: string;
+	dims: number;
+	label: string;
+};
+
+function layoutLabel(method: string, dims: number): string {
+	if (method === 'som') return 'SOM grid';
+	if (method === 'umap') return 'UMAP';
+	if (method === 'pca') return 'PCA';
+	return `${method} ${dims}d`;
+}
+
+/**
+ * The 2D reductions a run can be laid out on, plus which one to show by default.
+ *
+ * A layout is decoupled from the reduction the clustering was computed on: any
+ * 2D reduction (umap_2d, som_2d, ...) can display any run's clusters. The
+ * default prefers the run's own reduction when it is itself 2D (so a SOM
+ * codebook run opens on the SOM grid), then a UMAP, then any 2D reduction.
+ *
+ * When no 2D reduction exists, `layouts` instead holds the run's own (non-2D)
+ * reduction so the view still renders from its first two dimensions — so
+ * callers must treat `dims` as load-bearing rather than assuming every Layout
+ * is 2D.
+ */
+export function getLayouts(clusterRunId: number): {
+	layouts: Layout[];
+	defaultReductionId: number | null;
+} {
 	const run = db
 		.select({ reductionId: clusterRuns.reductionId })
 		.from(clusterRuns)
 		.where(eq(clusterRuns.clusterRunId, clusterRunId))
 		.get();
 
-	if (!run) return [];
+	if (!run) return { layouts: [], defaultReductionId: null };
 
+	const cols = {
+		reductionId: reductions.reductionId,
+		method: reductions.method,
+		dims: reductions.targetDimensions
+	};
+
+	const twoD = db
+		.select(cols)
+		.from(reductions)
+		.where(eq(reductions.targetDimensions, 2))
+		.orderBy(reductions.reductionId)
+		.all();
+
+	const chosen = twoD.length > 0
+		? twoD
+		: db.select(cols).from(reductions).where(eq(reductions.reductionId, run.reductionId)).all();
+
+	if (chosen.length === 0) return { layouts: [], defaultReductionId: null };
+
+	const layouts = chosen.map((r) => ({ ...r, label: layoutLabel(r.method, r.dims) }));
+	const ownIs2D = twoD.some((r) => r.reductionId === run.reductionId);
+	const defaultReductionId =
+		twoD.length === 0
+			? chosen[0].reductionId
+			: ownIs2D
+				? run.reductionId
+				: (twoD.find((r) => r.method === 'umap') ?? twoD[0]).reductionId;
+
+	return { layouts, defaultReductionId };
+}
+
+export function getLayoutData(clusterRunId: number, reductionId: number) {
 	const rawRows = db
 		.select({
 			itemId: items.itemId,
@@ -68,7 +131,7 @@ export function getScatterPlotData(clusterRunId: number) {
 			reductionCoordinates,
 			and(
 				eq(reductionCoordinates.itemId, items.itemId),
-				eq(reductionCoordinates.reductionId, run.reductionId)
+				eq(reductionCoordinates.reductionId, reductionId)
 			)
 		)
 		.innerJoin(

--- a/client/src/routes/runs/[clusterRunId]/+page.server.ts
+++ b/client/src/routes/runs/[clusterRunId]/+page.server.ts
@@ -1,8 +1,8 @@
 import { error } from '@sveltejs/kit';
 import { getRun, getClusterDetails, getCritique } from '$lib/server/queries/runs';
-import { getLayouts, getLayoutData } from '$lib/server/queries/items';
+import { getLayouts, getLayoutData, getSomGrid } from '$lib/server/queries/items';
 
-export function load({ params }) {
+export function load({ params, url }) {
 	const clusterRunId = Number(params.clusterRunId);
 	if (Number.isNaN(clusterRunId)) throw error(400, 'Invalid cluster run ID');
 
@@ -11,12 +11,18 @@ export function load({ params }) {
 
 	const { layouts, defaultReductionId } = getLayouts(clusterRunId);
 
+	// ?layout=<reductionId> selects a layout; fall back to the default.
+	const requested = Number(url.searchParams.get('layout'));
+	const active = layouts.find((l) => l.reductionId === requested) ??
+		layouts.find((l) => l.reductionId === defaultReductionId) ?? null;
+
 	return {
 		run,
 		clusters: getClusterDetails(clusterRunId),
 		critique: getCritique(clusterRunId),
 		layouts,
-		activeReductionId: defaultReductionId,
-		points: defaultReductionId == null ? [] : getLayoutData(clusterRunId, defaultReductionId)
+		activeReductionId: active?.reductionId ?? null,
+		points: active == null ? [] : getLayoutData(clusterRunId, active.reductionId),
+		somGrid: active?.method === 'som' ? getSomGrid(active.reductionId) : null
 	};
 }

--- a/client/src/routes/runs/[clusterRunId]/+page.server.ts
+++ b/client/src/routes/runs/[clusterRunId]/+page.server.ts
@@ -1,6 +1,6 @@
 import { error } from '@sveltejs/kit';
 import { getRun, getClusterDetails, getCritique } from '$lib/server/queries/runs';
-import { getScatterPlotData } from '$lib/server/queries/items';
+import { getLayouts, getLayoutData } from '$lib/server/queries/items';
 
 export function load({ params }) {
 	const clusterRunId = Number(params.clusterRunId);
@@ -9,10 +9,14 @@ export function load({ params }) {
 	const run = getRun(clusterRunId);
 	if (!run) throw error(404, 'Cluster run not found');
 
+	const { layouts, defaultReductionId } = getLayouts(clusterRunId);
+
 	return {
 		run,
 		clusters: getClusterDetails(clusterRunId),
 		critique: getCritique(clusterRunId),
-		points: getScatterPlotData(clusterRunId)
+		layouts,
+		activeReductionId: defaultReductionId,
+		points: defaultReductionId == null ? [] : getLayoutData(clusterRunId, defaultReductionId)
 	};
 }

--- a/client/src/routes/runs/[clusterRunId]/+page.svelte
+++ b/client/src/routes/runs/[clusterRunId]/+page.svelte
@@ -4,12 +4,22 @@
 	import EmptyState from '$lib/components/EmptyState.svelte';
 	import Input from '$lib/components/Input.svelte';
 	import ScatterPlot from '$lib/components/ScatterPlot.svelte';
+	import SomGrid from '$lib/components/SomGrid.svelte';
 	import ItemDrawer from '$lib/components/ItemDrawer.svelte';
 	import ClusterDrawer from '$lib/components/ClusterDrawer.svelte';
 	import { createClusterColorScale } from '$lib/cluster-colors';
 	import { formatTime, formatPercent } from '$lib/format';
+	import { goto } from '$app/navigation';
 
 	let { data } = $props();
+
+	const activeLayout = $derived(
+		data.layouts.find((l) => l.reductionId === data.activeReductionId) ?? null
+	);
+
+	function selectLayout(reductionId: number) {
+		goto(`?layout=${reductionId}`, { noScroll: true, keepFocus: true });
+	}
 
 	let search = $state('');
 	let showCritique = $state(false);
@@ -141,10 +151,24 @@
 	</div>
 
 	<div class="main-area">
+		{#if data.layouts.length > 1}
+			<div class="layout-switch">
+				{#each data.layouts as layout}
+					<button
+						class="layout-btn"
+						class:active={layout.reductionId === data.activeReductionId}
+						onclick={() => selectLayout(layout.reductionId)}
+					>{layout.label}</button>
+				{/each}
+			</div>
+		{/if}
+
 		{#if data.points.length === 0}
 			<div class="container stack">
-				<EmptyState message="No UMAP data available for this run." />
+				<EmptyState message="No layout data available for this run." />
 			</div>
+		{:else if activeLayout?.method === 'som' && data.somGrid}
+			<SomGrid points={data.points} somGrid={data.somGrid} getColor={getClusterColor} {focusClusterId} onSelect={handlePointSelect} />
 		{:else}
 			<ScatterPlot points={data.points} getColor={getClusterColor} {focusClusterId} onSelect={handlePointSelect} />
 		{/if}
@@ -231,6 +255,26 @@
 		flex: 1;
 		position: relative;
 		overflow: hidden;
+	}
+
+	.layout-switch {
+		position: absolute;
+		top: 0.5rem;
+		left: 0.5rem;
+		z-index: 5;
+		display: flex;
+		gap: 0.5rem;
+	}
+
+	.layout-btn {
+		padding: 0.25rem 0.75rem;
+		font-size: 0.8125rem;
+	}
+
+	.layout-btn.active {
+		background: var(--color-bg);
+		color: var(--color-fg);
+		border: 1px solid var(--color-fg);
 	}
 
 	.rail-header {

--- a/fluster/config/plan.py
+++ b/fluster/config/plan.py
@@ -31,8 +31,23 @@ class UMAPReduction(BaseModel):
     min_dist: float = 0.1
 
 
+class SOMReduction(BaseModel):
+    """Self-organizing map. Always a 2D grid; produces grid coordinates per item
+    plus a codebook (stored in `som_nodes`). grid_x/grid_y default to an auto
+    size (~5*sqrt(n) total nodes, squarish) resolved at reduction time."""
+
+    method: Literal["som"] = "som"
+    target_dimensions: Literal[2] = 2
+    grid_x: int | None = None
+    grid_y: int | None = None
+    sigma: float = 1.0
+    learning_rate: float = 0.5
+    num_iteration: int = 1000
+    random_state: int = SEED
+
+
 ReductionConfig = Annotated[
-    PCAReduction | UMAPReduction, Field(discriminator="method")
+    PCAReduction | UMAPReduction | SOMReduction, Field(discriminator="method")
 ]
 
 

--- a/fluster/config/plan.py
+++ b/fluster/config/plan.py
@@ -67,6 +67,10 @@ class ClusteringConfig(BaseModel):
     method: Literal["hdbscan", "agglomerative"] = "hdbscan"
     reduction: str = "umap_8d"  # Format: "{method}_{dimensions}d"
     params: dict = Field(default_factory=dict)
+    # "coordinates" clusters each item's reduction coordinates directly.
+    # "codebook" clusters a SOM's node weights (two-level SOM) and propagates
+    # each node's cluster to the items whose best-matching unit it is.
+    target: Literal["coordinates", "codebook"] = "coordinates"
 
 
 class ImageConfig(BaseModel):

--- a/fluster/db/schema.py
+++ b/fluster/db/schema.py
@@ -108,7 +108,7 @@ CREATE TABLE IF NOT EXISTS reductions (
     target_dimensions   INTEGER NOT NULL,
     params_json         TEXT NOT NULL DEFAULT '{}',
     created_at          TEXT NOT NULL DEFAULT (datetime('now')),
-    CHECK (method IN ('pca', 'umap')),
+    CHECK (method IN ('pca', 'umap', 'som')),
     CHECK (json_valid(params_json))
 );
 
@@ -120,6 +120,20 @@ CREATE TABLE IF NOT EXISTS reduction_coordinates (
     FOREIGN KEY (reduction_id) REFERENCES reductions (reduction_id),
     FOREIGN KEY (item_id)      REFERENCES items (item_id),
     CHECK (json_valid(coordinates_json))
+);
+
+-- One row per SOM grid node: its codebook weight vector (in the SOM's input
+-- space) and U-matrix distance. Written alongside a method='som' reduction.
+CREATE TABLE IF NOT EXISTS som_nodes (
+    reduction_id    INTEGER NOT NULL,
+    node_index      INTEGER NOT NULL,
+    grid_i          INTEGER NOT NULL,
+    grid_j          INTEGER NOT NULL,
+    weight_json     TEXT NOT NULL,
+    umatrix_dist    REAL NOT NULL,
+    PRIMARY KEY (reduction_id, node_index),
+    FOREIGN KEY (reduction_id) REFERENCES reductions (reduction_id),
+    CHECK (json_valid(weight_json))
 );
 """
 

--- a/fluster/pipeline/cluster.py
+++ b/fluster/pipeline/cluster.py
@@ -7,7 +7,7 @@ import hdbscan
 import numpy as np
 from sklearn.cluster import AgglomerativeClustering
 
-from fluster.config.plan import Plan
+from fluster.config.plan import ClusteringConfig, Plan
 
 
 def _parse_reduction_ref(ref: str) -> tuple[str, int]:
@@ -49,6 +49,86 @@ def load_coordinates(
     return item_ids, coords
 
 
+def load_codebook(
+    conn: sqlite3.Connection, reduction_id: int
+) -> tuple[list[tuple[int, int]], np.ndarray]:
+    """Load a SOM codebook as (grid_cells, weights_matrix).
+
+    grid_cells[k] is the (grid_i, grid_j) of the k-th node; weights[k] is its
+    weight vector. Rows are ordered by node_index.
+    """
+    rows = conn.execute(
+        "SELECT grid_i, grid_j, weight_json FROM som_nodes "
+        "WHERE reduction_id = ? ORDER BY node_index",
+        (reduction_id,),
+    ).fetchall()
+
+    if not rows:
+        return [], np.empty((0, 0))
+
+    cells = [(r["grid_i"], r["grid_j"]) for r in rows]
+    weights = np.array(
+        [json.loads(r["weight_json"]) for r in rows],
+        dtype=np.float32,
+    )
+    return cells, weights
+
+
+def _run_clustering(
+    method: str, matrix: np.ndarray, params: dict
+) -> tuple[np.ndarray, np.ndarray]:
+    """Cluster a matrix with the named method, returning (labels, probabilities).
+
+    Only parameters relevant to the chosen method are passed through.
+    """
+    if method == "hdbscan":
+        hdbscan_params = {
+            k: v for k, v in params.items()
+            if k in ('min_cluster_size', 'min_samples', 'cluster_selection_method', 'cluster_selection_epsilon')
+        }
+        clusterer = hdbscan.HDBSCAN(**hdbscan_params)
+        clusterer.fit(matrix)
+        return clusterer.labels_, clusterer.probabilities_
+    elif method == "agglomerative":
+        agglom_params = {
+            k: v for k, v in params.items()
+            if k in ('n_clusters', 'linkage')
+        }
+        labels = AgglomerativeClustering(**agglom_params).fit_predict(matrix)
+        return labels, np.ones(len(labels), dtype=np.float64)
+    else:
+        raise ValueError(f"Unknown clustering method '{method}'")
+
+
+def _store_cluster_run(
+    conn: sqlite3.Connection,
+    reduction_id: int,
+    method: str,
+    params: dict,
+    item_ids: list[int],
+    labels,
+    probabilities,
+) -> int:
+    """Insert a cluster_run and its per-item assignments. Commits."""
+    cursor = conn.execute(
+        "INSERT INTO cluster_runs (reduction_id, method, params_json) VALUES (?, ?, ?)",
+        (reduction_id, method, json.dumps(params, sort_keys=True)),
+    )
+    cluster_run_id = cursor.lastrowid
+
+    conn.executemany(
+        "INSERT INTO cluster_assignments "
+        "(cluster_run_id, item_id, cluster_id, membership_probability) "
+        "VALUES (?, ?, ?, ?)",
+        [
+            (cluster_run_id, item_id, int(label), float(prob))
+            for item_id, label, prob in zip(item_ids, labels, probabilities)
+        ],
+    )
+    conn.commit()
+    return cluster_run_id
+
+
 def _cluster_run_exists(
     conn: sqlite3.Connection, reduction_id: int, method: str, params: dict
 ) -> bool:
@@ -61,16 +141,53 @@ def _cluster_run_exists(
     return row is not None
 
 
+def _cluster_codebook(
+    conn: sqlite3.Connection,
+    reduction_id: int,
+    cluster_config: ClusteringConfig,
+) -> tuple[list[int], list, list] | None:
+    """Cluster a SOM codebook and propagate node clusters to items by BMU.
+
+    Returns (item_ids, labels, probabilities), or None if there is nothing to
+    cluster (no codebook or no items).
+    """
+    cells, weights = load_codebook(conn, reduction_id)
+    if len(cells) == 0:
+        return None
+
+    node_labels, node_probs = _run_clustering(
+        cluster_config.method, weights, cluster_config.params
+    )
+    cell_to_cluster = {
+        cell: (int(label), float(prob))
+        for cell, label, prob in zip(cells, node_labels, node_probs)
+    }
+
+    item_ids, coords = load_coordinates(conn, reduction_id)
+    if len(item_ids) == 0:
+        return None
+
+    labels, probabilities = [], []
+    for grid_i, grid_j in coords:
+        label, prob = cell_to_cluster[(int(grid_i), int(grid_j))]
+        labels.append(label)
+        probabilities.append(prob)
+    return item_ids, labels, probabilities
+
+
 def cluster_items(
     conn: sqlite3.Connection,
     plan: Plan,
 ) -> dict:
     """Run all configured clustering passes.
 
-    Each ClusteringConfig in the plan specifies a reduction reference
-    (e.g. 'umap_8d') and HDBSCAN params. Idempotent — skips runs
-    that already exist with identical params.
+    Each ClusteringConfig names a reduction (e.g. 'umap_8d') and a clustering
+    method. With target='coordinates' (default) the items' reduction coordinates
+    are clustered directly. With target='codebook' the reduction must be a SOM:
+    its node weights are clustered and each node's cluster propagates to the
+    items whose best-matching unit it is (a two-level SOM).
 
+    Idempotent — skips runs that already exist with identical params.
     Returns a summary dict.
     """
     created = 0
@@ -87,59 +204,44 @@ def cluster_items(
             )
 
         reduction_id = reduction["reduction_id"]
-        params = cluster_config.params
 
-        if _cluster_run_exists(conn, reduction_id, cluster_config.method, params):
+        # The codebook target is recorded in params so a codebook run never
+        # collides with a coordinates run on the same reduction; coordinates
+        # runs keep their params untouched.
+        store_params = dict(cluster_config.params)
+        if cluster_config.target == "codebook":
+            store_params["target"] = "codebook"
+
+        if _cluster_run_exists(conn, reduction_id, cluster_config.method, store_params):
             skipped += 1
             continue
 
-        item_ids, coords = load_coordinates(conn, reduction_id)
-
-        if len(item_ids) == 0:
-            skipped += 1
-            continue
-
-        if cluster_config.method == "hdbscan":
-            # Filter params to only include HDBSCAN-specific parameters
-            hdbscan_params = {
-                k: v for k, v in params.items() 
-                if k in ('min_cluster_size', 'min_samples', 'cluster_selection_method', 'cluster_selection_epsilon')
-            }
-            clusterer = hdbscan.HDBSCAN(**hdbscan_params)
-            clusterer.fit(coords)
-            labels = clusterer.labels_
-            probabilities = clusterer.probabilities_
-        elif cluster_config.method == "agglomerative":
-            # Filter params to only include AgglomerativeClustering-specific parameters
-            agglom_params = {
-                k: v for k, v in params.items() 
-                if k in ('n_clusters', 'linkage')
-            }
-            clusterer = AgglomerativeClustering(**agglom_params)
-            labels = clusterer.fit_predict(coords)
-            probabilities = np.ones(len(labels), dtype=np.float64)
+        if cluster_config.target == "codebook":
+            if method_name != "som":
+                raise ValueError(
+                    f"target='codebook' requires a SOM reduction, "
+                    f"got '{cluster_config.reduction}'."
+                )
+            result = _cluster_codebook(conn, reduction_id, cluster_config)
         else:
-            raise ValueError(f"Unknown clustering method '{cluster_config.method}'")
+            item_ids, coords = load_coordinates(conn, reduction_id)
+            if len(item_ids) == 0:
+                result = None
+            else:
+                labels, probabilities = _run_clustering(
+                    cluster_config.method, coords, cluster_config.params
+                )
+                result = (item_ids, labels, probabilities)
 
-        cursor = conn.execute(
-            "INSERT INTO cluster_runs "
-            "(reduction_id, method, params_json) VALUES (?, ?, ?)",
-            (reduction_id, cluster_config.method, json.dumps(params, sort_keys=True)),
+        if result is None:
+            skipped += 1
+            continue
+
+        item_ids, labels, probabilities = result
+        _store_cluster_run(
+            conn, reduction_id, cluster_config.method, store_params,
+            item_ids, labels, probabilities,
         )
-        cluster_run_id = cursor.lastrowid
-
-        conn.executemany(
-            "INSERT INTO cluster_assignments "
-            "(cluster_run_id, item_id, cluster_id, membership_probability) "
-            "VALUES (?, ?, ?, ?)",
-            [
-                (cluster_run_id, item_id, int(label), float(prob))
-                for item_id, label, prob in zip(item_ids, labels, probabilities)
-            ],
-        )
-
-        conn.commit()
-
         created += 1
 
     return {

--- a/fluster/pipeline/reduce.py
+++ b/fluster/pipeline/reduce.py
@@ -1,15 +1,17 @@
-"""reduce_items — dimensionality reduction via PCA and/or UMAP."""
+"""reduce_items — dimensionality reduction via PCA, UMAP, and/or SOM."""
 
 import json
+import math
 import sqlite3
 import struct
 import warnings
 
 import numpy as np
+from minisom import MiniSom
 from sklearn.decomposition import PCA
 from umap import UMAP
 
-from fluster.config.plan import PCAReduction, Plan, UMAPReduction
+from fluster.config.plan import PCAReduction, Plan, SOMReduction, UMAPReduction
 from fluster.config.settings import SEED
 
 
@@ -91,6 +93,59 @@ def _store_reduction(
     return reduction_id
 
 
+def _assert_som_supported(conn: sqlite3.Connection) -> None:
+    """Fail fast (and clearly) on pre-SOM project databases.
+
+    SOM support widened the reductions.method CHECK to admit 'som'. We don't
+    migrate old databases in place (SOM is opt-in), so a project created before
+    this feature would reject the insert deep inside training. Catch it up front.
+    """
+    row = conn.execute(
+        "SELECT sql FROM sqlite_master WHERE type='table' AND name='reductions'"
+    ).fetchone()
+    if row is not None and "'som'" not in row[0]:
+        raise RuntimeError(
+            "This project's database predates SOM support, so it can't store a "
+            "SOM reduction. Re-create the project with `fluster init` (and re-run "
+            "the pipeline) to use the grid view."
+        )
+
+
+def _auto_grid_size(n_samples: int) -> tuple[int, int]:
+    """A squarish grid with ~5*sqrt(n) total nodes (a common SOM heuristic)."""
+    side = max(2, round(math.sqrt(5 * math.sqrt(max(n_samples, 1)))))
+    return side, side
+
+
+def _store_som_nodes(
+    conn: sqlite3.Connection,
+    reduction_id: int,
+    weights: np.ndarray,
+    distance_map: np.ndarray,
+) -> None:
+    """Persist the SOM codebook: one row per grid node with its weight vector
+    (in the SOM's input space) and U-matrix distance."""
+    grid_x, grid_y = weights.shape[0], weights.shape[1]
+    conn.executemany(
+        "INSERT INTO som_nodes "
+        "(reduction_id, node_index, grid_i, grid_j, weight_json, umatrix_dist) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        [
+            (
+                reduction_id,
+                i * grid_y + j,
+                i,
+                j,
+                json.dumps(weights[i, j].tolist()),
+                float(distance_map[i, j]),
+            )
+            for i in range(grid_x)
+            for j in range(grid_y)
+        ],
+    )
+    conn.commit()
+
+
 def reduce_items(
     conn: sqlite3.Connection,
     plan: Plan,
@@ -100,6 +155,7 @@ def reduce_items(
     Pipeline per the plan:
     1. Optional PCA pre-reduction
     2. UMAP reductions (typically 2D and 8D)
+    3. Optional SOM grid reduction (opt-in; also writes a codebook to som_nodes)
 
     Each reduction is idempotent — skipped if it already exists.
     Returns a summary dict.
@@ -199,6 +255,48 @@ def reduce_items(
                 },
                 item_ids, coords,
             )
+            created += 1
+
+        elif isinstance(reduction_config, SOMReduction):
+            # SOM is always a 2D grid (one reduction per model, like umap_2d).
+            if _reduction_exists(conn, model_name, "som", 2):
+                skipped += 1
+                continue
+
+            _assert_som_supported(conn)
+
+            n_samples, input_len = working.shape
+            auto_x, auto_y = _auto_grid_size(n_samples)
+            grid_x = reduction_config.grid_x or auto_x
+            grid_y = reduction_config.grid_y or auto_y
+
+            som = MiniSom(
+                grid_x,
+                grid_y,
+                input_len,
+                sigma=reduction_config.sigma,
+                learning_rate=reduction_config.learning_rate,
+                random_seed=reduction_config.random_state,
+            )
+            som.random_weights_init(working)
+            som.train(working, reduction_config.num_iteration, random_order=True)
+
+            # Each item's coordinates are its best-matching unit (grid cell).
+            coords = np.array([som.winner(v) for v in working], dtype=np.float32)
+
+            reduction_id = _store_reduction(
+                conn, model_name, "som", 2,
+                {
+                    "grid_x": grid_x,
+                    "grid_y": grid_y,
+                    "sigma": reduction_config.sigma,
+                    "learning_rate": reduction_config.learning_rate,
+                    "num_iteration": reduction_config.num_iteration,
+                    "random_state": reduction_config.random_state,
+                },
+                item_ids, coords,
+            )
+            _store_som_nodes(conn, reduction_id, som.get_weights(), som.distance_map())
             created += 1
 
     return {"reductions_created": created, "skipped": skipped}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "sqlite-vec>=0.1.6",
     "hdbscan>=0.8.40",
     "umap-learn>=0.5",
+    "minisom>=2.3",
     "rich>=13.9",
     "sentence-transformers>=3.3",
     "openai>=1.59",

--- a/tests/test_cluster_codebook.py
+++ b/tests/test_cluster_codebook.py
@@ -1,0 +1,158 @@
+"""Tests for SOM codebook clustering in cluster_items (issue #13, phase 2)."""
+
+import json
+
+import pytest
+
+from fluster.config.plan import (
+    ClusteringConfig,
+    PCAReduction,
+    Plan,
+    SOMReduction,
+    UMAPReduction,
+)
+from fluster.pipeline.cluster import cluster_items
+from fluster.pipeline.embed import embed_items
+from fluster.pipeline.ingest import ingest_rows
+from fluster.pipeline.materialize import materialize_items
+from fluster.pipeline.reduce import reduce_items
+
+
+def _write_csv(path, header, *rows):
+    csv_file = path / "data.csv"
+    csv_file.write_text("\n".join([header] + list(rows)) + "\n")
+    return csv_file
+
+
+def _setup_som(pdir, conn, reductions, count=30):
+    """Ingest/materialize/embed `count` items and run the given reductions."""
+    for i in range(count):
+        (pdir / f"item{i}.txt").write_text(
+            f"Item {i} about {'science' if i % 2 == 0 else 'art'} topic {i}."
+        )
+    rows = [f"item{i},{pdir}/item{i}.txt" for i in range(count)]
+    csv_file = _write_csv(pdir, "name,file_path", *rows)
+    ingest_rows(conn, csv_file, pdir)
+    materialize_items(conn, pdir)
+    embed_items(conn, Plan())
+    reduce_items(conn, Plan(reductions=reductions))
+
+
+def _codebook_config(n_clusters=3):
+    return ClusteringConfig(
+        method="agglomerative",
+        reduction="som_2d",
+        target="codebook",
+        params={"n_clusters": n_clusters},
+    )
+
+
+# --- Basic codebook run ---
+
+def test_codebook_creates_run(project):
+    pdir, conn = project
+    _setup_som(pdir, conn, [PCAReduction(), SOMReduction(grid_x=4, grid_y=4, num_iteration=100)])
+
+    summary = cluster_items(conn, Plan(clustering=[_codebook_config()]))
+    assert summary["runs_created"] == 1
+
+    run = conn.execute("SELECT * FROM cluster_runs").fetchone()
+    assert run["method"] == "agglomerative"
+    params = json.loads(run["params_json"])
+    assert params["target"] == "codebook"
+    assert params["n_clusters"] == 3
+
+    # The run links to the SOM reduction.
+    reduction = conn.execute(
+        "SELECT method FROM reductions WHERE reduction_id = ?", (run["reduction_id"],)
+    ).fetchone()
+    assert reduction["method"] == "som"
+
+
+def test_codebook_assigns_all_items(project):
+    pdir, conn = project
+    _setup_som(pdir, conn, [PCAReduction(), SOMReduction(grid_x=4, grid_y=4, num_iteration=100)])
+
+    cluster_items(conn, Plan(clustering=[_codebook_config()]))
+
+    assignments = conn.execute("SELECT * FROM cluster_assignments").fetchall()
+    assert len(assignments) == 30
+    for a in assignments:
+        assert isinstance(a["cluster_id"], int)
+        assert a["membership_probability"] == 1.0  # agglomerative
+
+
+def test_codebook_propagates_by_cell(project):
+    """Items sharing a SOM grid cell must share a cluster (propagation by BMU)."""
+    pdir, conn = project
+    _setup_som(pdir, conn, [PCAReduction(), SOMReduction(grid_x=4, grid_y=4, num_iteration=100)])
+
+    cluster_items(conn, Plan(clustering=[_codebook_config()]))
+
+    rows = conn.execute(
+        """
+        SELECT rc.coordinates_json AS cell, ca.cluster_id AS cluster_id
+        FROM reduction_coordinates rc
+        JOIN reductions r ON rc.reduction_id = r.reduction_id
+        JOIN cluster_assignments ca ON ca.item_id = rc.item_id
+        WHERE r.method = 'som'
+        """
+    ).fetchall()
+
+    by_cell: dict[str, set[int]] = {}
+    for row in rows:
+        by_cell.setdefault(row["cell"], set()).add(row["cluster_id"])
+    for cell, clusters in by_cell.items():
+        assert len(clusters) == 1, f"cell {cell} split across clusters {clusters}"
+
+
+# --- Guard: codebook requires a SOM ---
+
+def test_codebook_requires_som_reduction(project):
+    pdir, conn = project
+    _setup_som(pdir, conn, [PCAReduction(), UMAPReduction(target_dimensions=2)])
+
+    plan = Plan(clustering=[
+        ClusteringConfig(
+            method="agglomerative", reduction="umap_2d",
+            target="codebook", params={"n_clusters": 3},
+        )
+    ])
+    with pytest.raises(ValueError, match="requires a SOM reduction"):
+        cluster_items(conn, plan)
+
+
+# --- Idempotency + coexistence ---
+
+def test_codebook_is_idempotent(project):
+    pdir, conn = project
+    _setup_som(pdir, conn, [PCAReduction(), SOMReduction(grid_x=4, grid_y=4, num_iteration=100)])
+
+    plan = Plan(clustering=[_codebook_config()])
+    cluster_items(conn, plan)
+    summary = cluster_items(conn, plan)
+    assert summary["runs_created"] == 0
+    assert summary["skipped"] == 1
+    assert conn.execute("SELECT COUNT(*) FROM cluster_runs").fetchone()[0] == 1
+
+
+def test_codebook_and_coordinates_coexist(project):
+    """A coordinates run and a codebook run can both exist over the same items."""
+    pdir, conn = project
+    _setup_som(
+        pdir, conn,
+        [PCAReduction(), UMAPReduction(target_dimensions=8),
+         SOMReduction(grid_x=4, grid_y=4, num_iteration=100)],
+    )
+
+    plan = Plan(clustering=[
+        ClusteringConfig(reduction="umap_8d", params={"min_cluster_size": 5}),
+        _codebook_config(),
+    ])
+    summary = cluster_items(conn, plan)
+    assert summary["runs_created"] == 2
+
+    methods = {
+        r["method"] for r in conn.execute("SELECT method FROM cluster_runs").fetchall()
+    }
+    assert methods == {"hdbscan", "agglomerative"}

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -11,6 +11,7 @@ from fluster.config.plan import (
     LLMProvider,
     PCAReduction,
     Plan,
+    SOMReduction,
     UMAPReduction,
     load_plan,
     save_plan,
@@ -113,6 +114,46 @@ def test_load_custom_reductions(tmp_path):
     assert len(plan.reductions) == 1
     assert isinstance(plan.reductions[0], UMAPReduction)
     assert plan.reductions[0].target_dimensions == 3
+
+
+def test_som_not_in_default_plan():
+    """SOM is opt-in — it must not be in the default reductions."""
+    plan = Plan()
+    assert not any(isinstance(r, SOMReduction) for r in plan.reductions)
+
+
+def test_som_reduction_defaults():
+    som = SOMReduction()
+    assert som.method == "som"
+    assert som.target_dimensions == 2
+    assert som.grid_x is None and som.grid_y is None
+    assert som.num_iteration == 1000
+    assert som.random_state == 42
+
+
+def test_load_som_reduction(tmp_path):
+    """A SOM entry in plan.yaml parses to a SOMReduction (union discrimination)."""
+    path = tmp_path / "plan.yaml"
+    path.write_text(yaml.dump({
+        "reductions": [
+            {"method": "pca", "target_dimensions": 50},
+            {"method": "som", "grid_x": 8, "grid_y": 8, "num_iteration": 500},
+        ]
+    }))
+
+    plan = load_plan(path)
+    assert isinstance(plan.reductions[0], PCAReduction)
+    som = plan.reductions[1]
+    assert isinstance(som, SOMReduction)
+    assert som.grid_x == 8 and som.grid_y == 8
+    assert som.num_iteration == 500
+
+
+def test_som_roundtrip(tmp_path):
+    plan = Plan(reductions=[PCAReduction(), SOMReduction(grid_x=10, grid_y=10)])
+    path = tmp_path / "plan.yaml"
+    save_plan(plan, path)
+    assert load_plan(path) == plan
 
 
 def test_load_invalid_reduction_method(tmp_path):

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -174,6 +174,29 @@ def test_custom_clustering_params():
     assert config.params["min_samples"] == 3
 
 
+def test_clustering_target_defaults_to_coordinates():
+    assert ClusteringConfig().target == "coordinates"
+
+
+def test_clustering_codebook_target_roundtrips(tmp_path):
+    plan = Plan(clustering=[
+        ClusteringConfig(
+            method="agglomerative", reduction="som_2d",
+            target="codebook", params={"n_clusters": 5},
+        )
+    ])
+    path = tmp_path / "plan.yaml"
+    save_plan(plan, path)
+    loaded = load_plan(path)
+    assert loaded.clustering[0].target == "codebook"
+    assert loaded == plan
+
+
+def test_invalid_clustering_target():
+    with pytest.raises(ValidationError):
+        ClusteringConfig(target="nonsense")
+
+
 # --- UMAP options (issue #8) ---
 
 

--- a/tests/test_reduce_som.py
+++ b/tests/test_reduce_som.py
@@ -1,0 +1,214 @@
+"""Tests for the SOM reduction path of reduce_items (issue #13, phase 1)."""
+
+import json
+
+import pytest
+
+from fluster.config.plan import PCAReduction, Plan, SOMReduction
+from fluster.pipeline.embed import embed_items
+from fluster.pipeline.ingest import ingest_rows
+from fluster.pipeline.materialize import materialize_items
+from fluster.pipeline.reduce import _auto_grid_size, reduce_items
+
+
+def _write_csv(path, header, *rows):
+    csv_file = path / "data.csv"
+    csv_file.write_text("\n".join([header] + list(rows)) + "\n")
+    return csv_file
+
+
+def _setup_items(pdir, conn, count=20):
+    for i in range(count):
+        (pdir / f"item{i}.txt").write_text(f"Item {i} with unique content about topic {i}.")
+    rows = [f"item{i},{pdir}/item{i}.txt" for i in range(count)]
+    csv_file = _write_csv(pdir, "name,file_path", *rows)
+    ingest_rows(conn, csv_file, pdir)
+    materialize_items(conn, pdir)
+    embed_items(conn, Plan())
+
+
+def _som_plan(**som_kwargs):
+    return Plan(reductions=[PCAReduction(), SOMReduction(**som_kwargs)])
+
+
+# --- Reduction + coordinates ---
+
+def test_som_creates_reduction(project):
+    pdir, conn = project
+    _setup_items(pdir, conn)
+
+    summary = reduce_items(conn, _som_plan(grid_x=4, grid_y=4, num_iteration=100))
+    assert summary["reductions_created"] == 2  # PCA + SOM
+
+    som = conn.execute(
+        "SELECT * FROM reductions WHERE method = 'som'"
+    ).fetchone()
+    assert som is not None
+    assert som["target_dimensions"] == 2
+    params = json.loads(som["params_json"])
+    assert params["grid_x"] == 4 and params["grid_y"] == 4
+    assert params["random_state"] == 42
+
+
+def test_som_coordinates_are_grid_cells(project):
+    pdir, conn = project
+    _setup_items(pdir, conn)
+    reduce_items(conn, _som_plan(grid_x=5, grid_y=5, num_iteration=100))
+
+    som = conn.execute("SELECT reduction_id FROM reductions WHERE method='som'").fetchone()
+    coords = conn.execute(
+        "SELECT coordinates_json FROM reduction_coordinates WHERE reduction_id = ?",
+        (som["reduction_id"],),
+    ).fetchall()
+    assert len(coords) == 20
+
+    for c in coords:
+        i, j = json.loads(c["coordinates_json"])
+        assert i == int(i) and j == int(j)
+        assert 0 <= i < 5 and 0 <= j < 5
+
+
+# --- Codebook (som_nodes) ---
+
+def test_som_nodes_populated(project):
+    pdir, conn = project
+    _setup_items(pdir, conn)
+    reduce_items(conn, _som_plan(grid_x=4, grid_y=4, num_iteration=100))
+
+    som = conn.execute("SELECT reduction_id FROM reductions WHERE method='som'").fetchone()
+    nodes = conn.execute(
+        "SELECT * FROM som_nodes WHERE reduction_id = ? ORDER BY node_index",
+        (som["reduction_id"],),
+    ).fetchall()
+    assert len(nodes) == 16  # 4 * 4
+
+    # node_index, grid_i, grid_j are consistent.
+    for n in nodes:
+        assert n["node_index"] == n["grid_i"] * 4 + n["grid_j"]
+        assert 0.0 <= n["umatrix_dist"] <= 1.0
+        weight = json.loads(n["weight_json"])
+        # PCA reduced 20 samples -> at most 20 components; codebook lives there.
+        assert len(weight) == 20
+
+
+# --- Idempotency ---
+
+def test_som_is_idempotent(project):
+    pdir, conn = project
+    _setup_items(pdir, conn)
+    plan = _som_plan(grid_x=4, grid_y=4, num_iteration=100)
+
+    reduce_items(conn, plan)
+    summary = reduce_items(conn, plan)
+    assert summary["reductions_created"] == 0
+    assert summary["skipped"] == 2
+
+    n_som = conn.execute("SELECT COUNT(*) FROM reductions WHERE method='som'").fetchone()[0]
+    assert n_som == 1
+    n_nodes = conn.execute("SELECT COUNT(*) FROM som_nodes").fetchone()[0]
+    assert n_nodes == 16
+
+
+# --- Determinism (seed 42) ---
+
+def test_som_is_deterministic(project):
+    pdir, conn = project
+    _setup_items(pdir, conn)
+    plan = _som_plan(grid_x=4, grid_y=4, num_iteration=100)
+
+    def _snapshot():
+        coords = conn.execute(
+            """
+            SELECT rc.item_id, rc.coordinates_json
+            FROM reduction_coordinates rc
+            JOIN reductions r ON rc.reduction_id = r.reduction_id
+            WHERE r.method = 'som' ORDER BY rc.item_id
+            """
+        ).fetchall()
+        nodes = conn.execute(
+            """
+            SELECT n.node_index, n.weight_json
+            FROM som_nodes n JOIN reductions r ON n.reduction_id = r.reduction_id
+            WHERE r.method = 'som' ORDER BY n.node_index
+            """
+        ).fetchall()
+        return (
+            [(c["item_id"], c["coordinates_json"]) for c in coords],
+            [(n["node_index"], n["weight_json"]) for n in nodes],
+        )
+
+    reduce_items(conn, plan)
+    first = _snapshot()
+
+    conn.execute("DELETE FROM som_nodes")
+    conn.execute("DELETE FROM reduction_coordinates")
+    conn.execute("DELETE FROM reductions")
+    conn.commit()
+
+    reduce_items(conn, plan)
+    second = _snapshot()
+
+    assert first == second
+
+
+# --- Custom + auto grid sizing ---
+
+def test_som_respects_custom_grid(project):
+    pdir, conn = project
+    _setup_items(pdir, conn)
+    reduce_items(conn, _som_plan(grid_x=3, grid_y=6, num_iteration=50))
+
+    som = conn.execute("SELECT reduction_id FROM reductions WHERE method='som'").fetchone()
+    n_nodes = conn.execute(
+        "SELECT COUNT(*) FROM som_nodes WHERE reduction_id = ?", (som["reduction_id"],)
+    ).fetchone()[0]
+    assert n_nodes == 18  # 3 * 6
+
+
+def test_auto_grid_size_squarish():
+    x, y = _auto_grid_size(1000)
+    assert x == y
+    assert 9 <= x <= 14  # ~sqrt(5*sqrt(1000)) ≈ 11
+    # Never degenerate, even for tiny inputs.
+    assert _auto_grid_size(1) == (2, 2)
+
+
+def test_som_auto_grid_used_when_unset(project):
+    pdir, conn = project
+    _setup_items(pdir, conn)
+    reduce_items(conn, _som_plan(num_iteration=50))
+
+    som = conn.execute("SELECT params_json FROM reductions WHERE method='som'").fetchone()
+    params = json.loads(som["params_json"])
+    expected_x, expected_y = _auto_grid_size(20)
+    assert params["grid_x"] == expected_x
+    assert params["grid_y"] == expected_y
+
+
+# --- Pre-SOM database guard ---
+
+def test_som_on_pre_som_db_raises(project):
+    pdir, conn = project
+    _setup_items(pdir, conn)
+
+    # Simulate a project created before SOM support: the reductions CHECK only
+    # admits pca/umap, so a method='som' insert would fail deep in the pipeline.
+    conn.executescript(
+        """
+        DROP TABLE reductions;
+        CREATE TABLE reductions (
+            reduction_id        INTEGER PRIMARY KEY AUTOINCREMENT,
+            embedding_reference TEXT NOT NULL,
+            method              TEXT NOT NULL,
+            target_dimensions   INTEGER NOT NULL,
+            params_json         TEXT NOT NULL DEFAULT '{}',
+            created_at          TEXT NOT NULL DEFAULT (datetime('now')),
+            CHECK (method IN ('pca', 'umap')),
+            CHECK (json_valid(params_json))
+        );
+        """
+    )
+
+    plan = Plan(reductions=[SOMReduction(grid_x=4, grid_y=4, num_iteration=50)])
+    with pytest.raises(RuntimeError, match="predates SOM support"):
+        reduce_items(conn, plan)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -174,3 +174,46 @@ def test_schema_idempotent(conn):
         "('rows','artifacts','items','item_artifacts','representations')"
     ).fetchone()[0]
     assert tables == 5
+
+
+def test_som_nodes_table_exists(conn):
+    row = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='som_nodes'"
+    ).fetchone()
+    assert row is not None
+
+
+def test_reductions_accepts_som_method(conn):
+    """The reductions.method CHECK admits 'som' (new schema)."""
+    conn.execute(
+        "INSERT INTO reductions (embedding_reference, method, target_dimensions) "
+        "VALUES (?, 'som', 2)",
+        ("model-x",),
+    )
+    row = conn.execute("SELECT method FROM reductions").fetchone()
+    assert row["method"] == "som"
+
+
+def test_reductions_rejects_unknown_method(conn):
+    with pytest.raises(Exception):
+        conn.execute(
+            "INSERT INTO reductions (embedding_reference, method, target_dimensions) "
+            "VALUES (?, 'tsne', 2)",
+            ("model-x",),
+        )
+
+
+def test_som_nodes_requires_valid_json(conn):
+    cur = conn.execute(
+        "INSERT INTO reductions (embedding_reference, method, target_dimensions) "
+        "VALUES (?, 'som', 2)",
+        ("model-x",),
+    )
+    reduction_id = cur.lastrowid
+    with pytest.raises(Exception):
+        conn.execute(
+            "INSERT INTO som_nodes "
+            "(reduction_id, node_index, grid_i, grid_j, weight_json, umatrix_dist) "
+            "VALUES (?, 0, 0, 0, 'not-json', 0.5)",
+            (reduction_id,),
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -143,6 +143,7 @@ dependencies = [
     { name = "fastapi" },
     { name = "hdbscan" },
     { name = "loguru" },
+    { name = "minisom" },
     { name = "ollama" },
     { name = "openai" },
     { name = "pillow" },
@@ -170,6 +171,7 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.115" },
     { name = "hdbscan", specifier = ">=0.8.40" },
     { name = "loguru", specifier = ">=0.7" },
+    { name = "minisom", specifier = ">=2.3" },
     { name = "ollama", specifier = ">=0.4" },
     { name = "openai", specifier = ">=1.59" },
     { name = "pillow", specifier = ">=10.0" },
@@ -600,6 +602,12 @@ sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec9
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
 ]
+
+[[package]]
+name = "minisom"
+version = "2.3.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/9c/999bc2f1bee4cfbb6157ac03db32f5a831322479151941bc997774c405c6/minisom-2.3.6.tar.gz", hash = "sha256:1fca9cfeef62b221a89930ad3422b7a24a2bd66ae43ef97332e165f5975c09f1", size = 13140, upload-time = "2026-02-11T12:04:56.267Z" }
 
 [[package]]
 name = "mpmath"
@@ -1642,6 +1650,12 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0f/8b/4b61d6e13f7108f36910df9ab4b58fd389cc2520d54d81b88660804aad99/torch-2.10.0-2-cp311-none-macosx_11_0_arm64.whl", hash = "sha256:418997cb02d0a0f1497cf6a09f63166f9f5df9f3e16c8a716ab76a72127c714f", size = 79423467, upload-time = "2026-02-10T21:44:48.711Z" },
     { url = "https://files.pythonhosted.org/packages/d3/54/a2ba279afcca44bbd320d4e73675b282fcee3d81400ea1b53934efca6462/torch-2.10.0-2-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:13ec4add8c3faaed8d13e0574f5cd4a323c11655546f91fbe6afa77b57423574", size = 79498202, upload-time = "2026-02-10T21:44:52.603Z" },
     { url = "https://files.pythonhosted.org/packages/ec/23/2c9fe0c9c27f7f6cb865abcea8a4568f29f00acaeadfc6a37f6801f84cb4/torch-2.10.0-2-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:e521c9f030a3774ed770a9c011751fb47c4d12029a3d6522116e48431f2ff89e", size = 79498254, upload-time = "2026-02-10T21:44:44.095Z" },
+    { url = "https://files.pythonhosted.org/packages/36/ab/7b562f1808d3f65414cd80a4f7d4bb00979d9355616c034c171249e1a303/torch-2.10.0-3-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:ac5bdcbb074384c66fa160c15b1ead77839e3fe7ed117d667249afce0acabfac", size = 915518691, upload-time = "2026-03-11T14:15:43.147Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/7a/abada41517ce0011775f0f4eacc79659bc9bc6c361e6bfe6f7052a6b9363/torch-2.10.0-3-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:98c01b8bb5e3240426dcde1446eed6f40c778091c8544767ef1168fc663a05a6", size = 915622781, upload-time = "2026-03-11T14:17:11.354Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/c6/4dfe238342ffdcec5aef1c96c457548762d33c40b45a1ab7033bb26d2ff2/torch-2.10.0-3-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:80b1b5bfe38eb0e9f5ff09f206dcac0a87aadd084230d4a36eea5ec5232c115b", size = 915627275, upload-time = "2026-03-11T14:16:11.325Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/f0/72bf18847f58f877a6a8acf60614b14935e2f156d942483af1ffc081aea0/torch-2.10.0-3-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:46b3574d93a2a8134b3f5475cfb98e2eb46771794c57015f6ad1fb795ec25e49", size = 915523474, upload-time = "2026-03-11T14:17:44.422Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/39/590742415c3030551944edc2ddc273ea1fdfe8ffb2780992e824f1ebee98/torch-2.10.0-3-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:b1d5e2aba4eb7f8e87fbe04f86442887f9167a35f092afe4c237dfcaaef6e328", size = 915632474, upload-time = "2026-03-11T14:15:13.666Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/8e/34949484f764dde5b222b7fe3fede43e4a6f0da9d7f8c370bb617d629ee2/torch-2.10.0-3-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:0228d20b06701c05a8f978357f657817a4a63984b0c90745def81c18aedfa591", size = 915523882, upload-time = "2026-03-11T14:14:46.311Z" },
     { url = "https://files.pythonhosted.org/packages/78/89/f5554b13ebd71e05c0b002f95148033e730d3f7067f67423026cc9c69410/torch-2.10.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:3282d9febd1e4e476630a099692b44fdc214ee9bf8ee5377732d9d9dfe5712e4", size = 145992610, upload-time = "2026-01-21T16:25:26.327Z" },
     { url = "https://files.pythonhosted.org/packages/ae/30/a3a2120621bf9c17779b169fc17e3dc29b230c29d0f8222f499f5e159aa8/torch-2.10.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:a2f9edd8dbc99f62bc4dfb78af7bf89499bca3d753423ac1b4e06592e467b763", size = 915607863, upload-time = "2026-01-21T16:25:06.696Z" },
     { url = "https://files.pythonhosted.org/packages/6f/3d/c87b33c5f260a2a8ad68da7147e105f05868c281c63d65ed85aa4da98c66/torch-2.10.0-cp311-cp311-win_amd64.whl", hash = "sha256:29b7009dba4b7a1c960260fc8ac85022c784250af43af9fb0ebafc9883782ebd", size = 113723116, upload-time = "2026-01-21T16:25:21.916Z" },


### PR DESCRIPTION
Closes #13.

Adds a **self-organizing-map (SOM) grid visualization** as an alternative to the UMAP point cloud, built on `minisom` and kept entirely within fluster's append-only, reproducible, "with receipts" model. SOM is **opt-in** — nothing changes for existing workflows unless you add it to `plan.yaml`.

## What you get

A SOM codebook run opens on a grid lattice instead of a scatter, and a **UMAP / SOM-grid toggle** lets you move between them on any run. Each grid cell is shaded by its U-matrix distance (topological seams), tinted by the cluster living there, and darkened by how many items landed in it. Hover for cell details; click to inspect.

```yaml
reductions:
  - { method: pca, target_dimensions: 50 }
  - { method: umap, target_dimensions: 2 }
  - { method: umap, target_dimensions: 8 }
  - { method: som }            # auto-sizes the grid if grid_x/grid_y omitted

clustering:
  - { method: hdbscan, reduction: umap_8d, params: { min_cluster_size: 5 } }
  - { method: agglomerative, reduction: som_2d, target: codebook, params: { n_clusters: 8 } }
```

## How it's built (4 commits, one per phase)

1. **`df7e976` — SOM reduction.** A new opt-in `SOMReduction` in the discriminated `ReductionConfig` union; `reduce_items` trains a MiniSom on the post-PCA matrix, stores each item's best-matching-unit grid cell as its 2D coordinates, and persists the codebook to a new additive `som_nodes` table (weights + U-matrix). Seed-fixed, idempotent.
2. **`0177eff` — Codebook clustering.** `ClusteringConfig.target` (`coordinates` default / `codebook`). Codebook mode clusters the SOM's node weights (two-level SOM) and propagates each node's cluster to the items in its cell — emitting ordinary `cluster_assignments`, so exemplars/label/critique are untouched.
3. **`cb70ca0` — Layout-decoupled query layer.** `getLayoutData(clusterRunId, reductionId)` + `getLayouts()` let any 2D reduction display any run's clusters. Also fixes a latent oddity where the scatter used the clustering reduction (`umap_8d`, 8 dims) instead of the dedicated `umap_2d`.
4. **`0c11d70` — Grid view.** `getSomGrid` + the `som_nodes` drizzle table, a `?layout=` query param, and the new `SomGrid.svelte` (CSS-grid lattice; focus-fade consistent with the scatter). README opt-in docs.

## Design decisions

- **minisom (Python pipeline), not midsommer (client).** Keeps the SOM stored, versioned, and reproducible like every other stage rather than recomputed per page load.
- **No migration framework — a surgical, opt-in break.** The only non-additive change is widening the `reductions.method` CHECK to admit `'som'`. Existing projects keep working for everything; enabling SOM on a pre-SOM DB fails fast with a clear "re-create the project" message. (`som_nodes` is purely additive.)
- **SOM as reduction + codebook-clustering-on-top**, reusing the existing reduction/cluster decoupling rather than inventing a new pipeline stage.

## Verification

- **Python:** full `pytest` suite green except two failures that **pre-exist on `main`** and are unrelated to this work (`test_default_clustering`, `test_cluster_stores_params` — both stem from `ClusteringConfig.params` defaulting to `{}`). New tests cover the SOM reduction, codebook clustering + propagation invariant, and the plan/schema changes.
- **Client:** no test harness, so `npm run check` (svelte-check) — passes with **zero new** errors (one pre-existing, unrelated `ItemDrawer.svelte` type error remains).
- **Runtime:** ran the app against a synthetic SOM project and confirmed via SSR HTML that a codebook run defaults to the grid (64 cells for an 8×8), the toggle swaps grid↔scatter, and a umap/hdbscan run defaults to the scatter.

## Follow-ups (not in scope here)

- The two pre-existing `ClusteringConfig.params` test failures on `main` (separate fix incoming).
- The pre-existing `ItemDrawer.svelte` typecheck error.
- SOM cells currently inspect their first item on click; a future per-cell item list in the drawer could be nicer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
