### PR TITLE
Reconcile cluster labels across the whole run for global consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 - Cluster (HDBSCAN or agglomerative)
 - Select exemplars from each cluster's core and outskirts
 - Label clusters with an LLM (BYO)
+- Reconcile labels across the whole run for consistency
 - Critique the clustering run
 - Keep an auditable trail of every step
 
@@ -112,7 +113,7 @@ fluster plan
 # Ingest a CSV — file_path column is optional
 fluster ingest-rows data.csv
 
-# Run the full pipeline (materialize → embed → reduce → cluster → exemplars → label → critique)
+# Run the full pipeline (materialize → embed → reduce → cluster → exemplars → label → reconcile → critique)
 fluster run
 
 # Check on jobs and logs

--- a/fluster/pipeline/reconcile.py
+++ b/fluster/pipeline/reconcile.py
@@ -1,0 +1,183 @@
+"""reconcile_labels — a global pass that renames cluster labels for consistency.
+
+Per-cluster labeling (see label.py) only ever sees one cluster at a time, so the
+label set can drift: duplicate labels, inconsistent granularity or voice, missed
+sibling structure. This step shows the LLM every cluster's label information at once
+and lets it revise labels for global consistency and disambiguation. It does not
+re-cluster — only the labels change.
+"""
+
+import json
+import sqlite3
+
+from pydantic import BaseModel
+
+from fluster.config.plan import LLMConfig
+from fluster.llm.client import generate_json
+
+
+class ReconciledLabel(BaseModel):
+    cluster_id: int
+    label: str
+    short_label: str
+    keywords: list[str]
+    reconcile_rationale: str  # what changed and why, or "unchanged"
+
+
+class ReconcileOutput(BaseModel):
+    clusters: list[ReconciledLabel]
+
+
+_PROMPT_TEMPLATE = """You are reviewing the labels for every cluster from a single clustering run so the label set reads consistently as a whole. Each cluster was labeled independently, so labels may collide, vary in granularity or voice, or miss obvious sibling relationships (e.g. "Cats" and "Dogs" would read better as "Domestic Felines" and "Domestic Canines").
+
+Below are all {n_clusters} clusters with their current labels:
+
+{cluster_blocks}
+
+Revise labels ONLY where it improves consistency or disambiguation across the whole set: resolve duplicate or near-duplicate labels, align granularity and voice, and surface sibling structure. Keep labels that are already clear and distinct unchanged.
+
+Respond with a JSON object {{"clusters": [...]}} containing exactly one entry per cluster above:
+- "cluster_id": the cluster's id (integer)
+- "label": the (possibly revised) descriptive label (1-5 words)
+- "short_label": the (possibly revised) very short label (1-2 words)
+- "keywords": an array of 3-5 keywords
+- "reconcile_rationale": a brief note on what changed and why, or "unchanged"
+
+Respond ONLY with the JSON object, no other text."""
+
+
+def _get_cluster_label_info(
+    conn: sqlite3.Connection, cluster_run_id: int
+) -> list[dict]:
+    """Return the latest label summary plus size for each non-noise cluster.
+
+    Uses the same MAX(cluster_summary_id) latest-row-wins resolution as the
+    downstream consumers (export.py, server.py, critique.py).
+    """
+    rows = conn.execute(
+        """
+        SELECT cs.cluster_summary_id, cs.cluster_id, cs.label_json,
+               (SELECT COUNT(*) FROM cluster_assignments ca
+                WHERE ca.cluster_run_id = cs.cluster_run_id
+                  AND ca.cluster_id = cs.cluster_id) AS size
+        FROM cluster_summaries cs
+        WHERE cs.cluster_run_id = ? AND cs.cluster_id >= 0
+          AND cs.cluster_summary_id IN (
+              SELECT MAX(cluster_summary_id) FROM cluster_summaries
+              WHERE cluster_run_id = ? GROUP BY cluster_id
+          )
+        ORDER BY cs.cluster_id
+        """,
+        (cluster_run_id, cluster_run_id),
+    ).fetchall()
+
+    return [
+        {
+            "cluster_summary_id": r["cluster_summary_id"],
+            "cluster_id": r["cluster_id"],
+            "size": r["size"],
+            "label_json": json.loads(r["label_json"]),
+        }
+        for r in rows
+    ]
+
+
+def _format_clusters(clusters: list[dict]) -> str:
+    """Render every cluster's label information into prompt blocks."""
+    blocks = []
+    for c in clusters:
+        lj = c["label_json"]
+        keywords = ", ".join(lj.get("keywords", []))
+        blocks.append(
+            f"Cluster {c['cluster_id']} (size {c['size']}):\n"
+            f"  label: {lj.get('label', '')}\n"
+            f"  short_label: {lj.get('short_label', '')}\n"
+            f"  keywords: {keywords}\n"
+            f"  rationale: {lj.get('rationale', '')}"
+        )
+    return "\n\n".join(blocks)
+
+
+def _reconcile_exists(conn: sqlite3.Connection, cluster_run_id: int) -> bool:
+    """Check whether this run's labels have already been reconciled."""
+    row = conn.execute(
+        "SELECT 1 FROM cluster_summaries "
+        "WHERE cluster_run_id = ? AND json_extract(label_json, '$.reconciled') "
+        "LIMIT 1",
+        (cluster_run_id,),
+    ).fetchone()
+    return row is not None
+
+
+def reconcile_labels(
+    conn: sqlite3.Connection,
+    cluster_run_id: int,
+    config: LLMConfig,
+    job_id: int | None = None,
+) -> dict:
+    """Rename cluster labels for global consistency using a single LLM call.
+
+    Gathers every cluster's current label information, sends it all to the LLM
+    in one call, and updates each cluster's summary in place with the revised
+    label. The pre-reconcile label is preserved under label_json.original.
+    Idempotent — skips runs whose labels are already reconciled, and runs with
+    fewer than two clusters (nothing to disambiguate).
+
+    Returns a summary dict.
+    """
+    if _reconcile_exists(conn, cluster_run_id):
+        return {"reconciled": 0, "skipped": True}
+
+    clusters = _get_cluster_label_info(conn, cluster_run_id)
+    if len(clusters) < 2:
+        return {"reconciled": 0, "skipped": True}
+
+    prompt = _PROMPT_TEMPLATE.format(
+        n_clusters=len(clusters),
+        cluster_blocks=_format_clusters(clusters),
+    )
+
+    result = generate_json(
+        task_name="reconcile_labels",
+        schema_model=ReconcileOutput,
+        prompt=prompt,
+        inputs={"cluster_run_id": cluster_run_id, "n_clusters": len(clusters)},
+        config=config,
+        conn=conn,
+        job_id=job_id,
+    )
+    revised = {r.cluster_id: r for r in result.clusters}
+
+    for c in clusters:
+        original = c["label_json"]
+        r = revised.get(c["cluster_id"])
+        if r is not None:
+            label, short_label, keywords = r.label, r.short_label, r.keywords
+            reconcile_rationale = r.reconcile_rationale
+        else:
+            # LLM omitted this cluster — keep its original label untouched.
+            label = original.get("label", "")
+            short_label = original.get("short_label", "")
+            keywords = original.get("keywords", [])
+            reconcile_rationale = "unchanged"
+
+        new_label_json = {
+            "label": label,
+            "short_label": short_label,
+            "rationale": original.get("rationale", ""),
+            "keywords": keywords,
+            "reconciled": True,
+            "reconcile_rationale": reconcile_rationale,
+            # The _reconcile_exists guard makes this run a no-op once a cluster
+            # is reconciled, so "original" never nests a prior "original".
+            "original": original,
+        }
+
+        conn.execute(
+            "UPDATE cluster_summaries SET label = ?, label_json = ? "
+            "WHERE cluster_summary_id = ?",
+            (label, json.dumps(new_label_json), c["cluster_summary_id"]),
+        )
+
+    conn.commit()
+    return {"reconciled": len(clusters), "skipped": False}

--- a/fluster/pipeline/run.py
+++ b/fluster/pipeline/run.py
@@ -11,6 +11,7 @@ from fluster.pipeline.embed import embed_items
 from fluster.pipeline.exemplars import select_exemplars
 from fluster.pipeline.label import label_clusters
 from fluster.pipeline.materialize import materialize_items
+from fluster.pipeline.reconcile import reconcile_labels
 from fluster.pipeline.reduce import reduce_items
 
 
@@ -42,7 +43,7 @@ def run_pipeline(
     job_id: int,
     on_step=None,
 ) -> dict:
-    """Execute the full pipeline: materialize → embed → reduce → cluster → exemplars → label → critique.
+    """Execute the full pipeline: materialize → embed → reduce → cluster → exemplars → label → reconcile → critique.
 
     Does NOT manage job lifecycle (create/start/succeed/fail) — the caller
     handles that. Raises PipelineCancelled if cancellation is requested.
@@ -88,11 +89,11 @@ def run_pipeline(
     log_job(conn, job_id, "cluster_items complete", payload=result)
 
     cluster_run_ids = _get_all_cluster_run_ids(conn)
-    total_steps = 4 + 3 * len(cluster_run_ids)
+    total_steps = 4 + 4 * len(cluster_run_ids)
     _step("cluster")
     _check_cancel(conn, job_id)
 
-    # Steps 5-7: per cluster_run
+    # Steps 5-8: per cluster_run
     for cluster_run_id in cluster_run_ids:
         log_job(conn, job_id, f"Starting select_exemplars for cluster_run {cluster_run_id}")
         result = select_exemplars(conn, cluster_run_id)
@@ -104,6 +105,12 @@ def run_pipeline(
         result = label_clusters(conn, cluster_run_id, plan.llm, job_id=job_id)
         log_job(conn, job_id, f"label_clusters complete for cluster_run {cluster_run_id}", payload=result)
         _step("label")
+        _check_cancel(conn, job_id)
+
+        log_job(conn, job_id, f"Starting reconcile_labels for cluster_run {cluster_run_id}")
+        result = reconcile_labels(conn, cluster_run_id, plan.llm, job_id=job_id)
+        log_job(conn, job_id, f"reconcile_labels complete for cluster_run {cluster_run_id}", payload=result)
+        _step("reconcile")
         _check_cancel(conn, job_id)
 
         log_job(conn, job_id, f"Starting critique_clusters for cluster_run {cluster_run_id}")

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -1,0 +1,245 @@
+"""Tests for reconcile_labels (Issue #21)."""
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from fluster.config.plan import LLMConfig, LLMProvider, Plan
+from fluster.pipeline.cluster import cluster_items
+from fluster.pipeline.embed import embed_items
+from fluster.pipeline.exemplars import select_exemplars
+from fluster.pipeline.ingest import ingest_rows
+from fluster.pipeline.label import label_clusters
+from fluster.pipeline.materialize import materialize_items
+from fluster.pipeline.reconcile import ReconcileOutput, reconcile_labels
+from fluster.pipeline.reduce import reduce_items
+
+
+def _write_csv(path, header, *rows):
+    csv_file = path / "data.csv"
+    csv_file.write_text("\n".join([header] + list(rows)) + "\n")
+    return csv_file
+
+
+def _mock_label_response():
+    return json.dumps({
+        "label": "Science Topics",
+        "short_label": "Science",
+        "rationale": "Items discuss scientific concepts.",
+        "keywords": ["science", "physics"],
+    })
+
+
+def _mock_reconcile_response(cluster_ids):
+    return json.dumps({
+        "clusters": [
+            {
+                "cluster_id": cid,
+                "label": f"Topic {cid}",
+                "short_label": f"T{cid}",
+                "keywords": ["alpha", "beta", "gamma"],
+                "reconcile_rationale": "Renamed to disambiguate from siblings.",
+            }
+            for cid in cluster_ids
+        ]
+    })
+
+
+def _llm_config():
+    return LLMConfig(provider=LLMProvider.openai, model="gpt-5-mini")
+
+
+def _setup_with_exemplars(pdir, conn, count=30):
+    """Run full pipeline through exemplar selection, return cluster_run_id."""
+    for i in range(count):
+        (pdir / f"item{i}.txt").write_text(
+            f"Item {i} about {'science and physics' if i % 2 == 0 else 'art and painting'} topic {i}."
+        )
+
+    rows = [f"item{i},{pdir}/item{i}.txt" for i in range(count)]
+    csv_file = _write_csv(pdir, "name,file_path", *rows)
+    ingest_rows(conn, csv_file, pdir)
+    materialize_items(conn, pdir)
+    plan = Plan()
+    embed_items(conn, plan)
+    reduce_items(conn, plan)
+    cluster_items(conn, plan)
+
+    run = conn.execute("SELECT cluster_run_id FROM cluster_runs LIMIT 1").fetchone()
+    run_id = run["cluster_run_id"]
+    select_exemplars(conn, run_id)
+    return run_id
+
+
+def _cluster_ids(conn, run_id):
+    rows = conn.execute(
+        "SELECT DISTINCT cluster_id FROM cluster_assignments "
+        "WHERE cluster_run_id = ? AND cluster_id >= 0 ORDER BY cluster_id",
+        (run_id,),
+    ).fetchall()
+    return [r["cluster_id"] for r in rows]
+
+
+def _label_run(mock_call, pdir, conn):
+    """Set up, label every cluster, and return (run_id, cluster_ids).
+
+    Skips the test when clustering produced fewer than two clusters — there is
+    nothing for reconciliation to disambiguate.
+    """
+    run_id = _setup_with_exemplars(pdir, conn)
+    mock_call.return_value = _mock_label_response()
+    label_clusters(conn, run_id, _llm_config())
+    ids = _cluster_ids(conn, run_id)
+    if len(ids) < 2:
+        pytest.skip("clustering produced fewer than two clusters")
+    return run_id, ids
+
+
+# --- Basic reconciliation ---
+
+@patch("fluster.llm.client._call_openai")
+def test_reconcile_updates_labels(mock_call, project):
+    pdir, conn = project
+    run_id, ids = _label_run(mock_call, pdir, conn)
+
+    mock_call.return_value = _mock_reconcile_response(ids)
+    summary = reconcile_labels(conn, run_id, _llm_config())
+
+    assert summary["skipped"] is False
+    assert summary["reconciled"] == len(ids)
+
+    for cid in ids:
+        row = conn.execute(
+            "SELECT label, label_json FROM cluster_summaries "
+            "WHERE cluster_run_id = ? AND cluster_id = ?",
+            (run_id, cid),
+        ).fetchone()
+        assert row["label"] == f"Topic {cid}"
+
+        data = json.loads(row["label_json"])
+        assert data["label"] == f"Topic {cid}"
+        assert data["short_label"] == f"T{cid}"
+        assert data["reconciled"] is True
+        assert data["reconcile_rationale"] == "Renamed to disambiguate from siblings."
+        # The original per-cluster label is preserved for provenance.
+        assert data["original"]["label"] == "Science Topics"
+
+
+# --- Idempotency ---
+
+@patch("fluster.llm.client._call_openai")
+def test_reconcile_is_idempotent(mock_call, project):
+    pdir, conn = project
+    run_id, ids = _label_run(mock_call, pdir, conn)
+
+    mock_call.return_value = _mock_reconcile_response(ids)
+    reconcile_labels(conn, run_id, _llm_config())
+    call_count_after_first = mock_call.call_count
+
+    summary = reconcile_labels(conn, run_id, _llm_config())
+    assert summary["skipped"] is True
+    assert summary["reconciled"] == 0
+    assert mock_call.call_count == call_count_after_first
+
+
+# --- Prompt content ---
+
+@patch("fluster.llm.client._call_openai")
+def test_reconcile_prompt_includes_all_clusters(mock_call, project):
+    pdir, conn = project
+    run_id, ids = _label_run(mock_call, pdir, conn)
+
+    mock_call.return_value = _mock_reconcile_response(ids)
+    reconcile_labels(conn, run_id, _llm_config())
+
+    prompt_sent = mock_call.call_args_list[-1][0][0]
+    for cid in ids:
+        assert f"Cluster {cid}" in prompt_sent
+    # Every cluster's current label info is shown.
+    assert "Science Topics" in prompt_sent
+
+
+# --- Audit trail ---
+
+@patch("fluster.llm.client._call_openai")
+def test_reconcile_logs_llm_call(mock_call, project):
+    pdir, conn = project
+    run_id, ids = _label_run(mock_call, pdir, conn)
+
+    mock_call.return_value = _mock_reconcile_response(ids)
+    reconcile_labels(conn, run_id, _llm_config())
+
+    logs = conn.execute(
+        "SELECT * FROM llm_calls WHERE task_name = 'reconcile_labels'"
+    ).fetchall()
+    assert len(logs) == 1
+    assert logs[0]["provider"] == "openai"
+    inputs = json.loads(logs[0]["input_json"])
+    assert inputs["cluster_run_id"] == run_id
+    assert inputs["n_clusters"] == len(ids)
+
+
+# --- Downstream consumers see the reconciled label ---
+
+@patch("fluster.llm.client._call_openai")
+def test_reconcile_visible_to_latest_row_query(mock_call, project):
+    pdir, conn = project
+    run_id, ids = _label_run(mock_call, pdir, conn)
+
+    mock_call.return_value = _mock_reconcile_response(ids)
+    reconcile_labels(conn, run_id, _llm_config())
+
+    # The MAX(cluster_summary_id) resolution used by export.py / server.py.
+    rows = conn.execute(
+        "SELECT cluster_id, label FROM cluster_summaries "
+        "WHERE cluster_run_id = ? AND cluster_summary_id IN ("
+        "  SELECT MAX(cluster_summary_id) FROM cluster_summaries "
+        "  WHERE cluster_run_id = ? GROUP BY cluster_id"
+        ")",
+        (run_id, run_id),
+    ).fetchall()
+    labels = {r["cluster_id"]: r["label"] for r in rows}
+    for cid in ids:
+        assert labels[cid] == f"Topic {cid}"
+
+
+# --- Skips when there is nothing to disambiguate ---
+
+@patch("fluster.llm.client._call_openai")
+def test_reconcile_skips_single_cluster(mock_call, project):
+    pdir, conn = project
+    run_id, ids = _label_run(mock_call, pdir, conn)
+
+    # Reduce the run to a single labeled cluster.
+    keep = ids[0]
+    conn.execute(
+        "DELETE FROM cluster_summaries WHERE cluster_run_id = ? AND cluster_id != ?",
+        (run_id, keep),
+    )
+    conn.commit()
+    call_count_before = mock_call.call_count
+
+    summary = reconcile_labels(conn, run_id, _llm_config())
+    assert summary["skipped"] is True
+    assert summary["reconciled"] == 0
+    assert mock_call.call_count == call_count_before
+
+
+# --- Schema validation ---
+
+def test_reconcile_output_schema():
+    data = {
+        "clusters": [
+            {
+                "cluster_id": 0,
+                "label": "Domestic Felines",
+                "short_label": "Felines",
+                "keywords": ["cat", "feline", "pet"],
+                "reconcile_rationale": "Aligned with 'Domestic Canines'.",
+            }
+        ]
+    }
+    result = ReconcileOutput.model_validate(data)
+    assert result.clusters[0].cluster_id == 0
+    assert result.clusters[0].label == "Domestic Felines"

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -47,6 +47,7 @@ _PIPELINE = "fluster.pipeline.run"
 
 
 @patch(f"{_PIPELINE}.critique_clusters", return_value={"critiqued": True, "skipped": False})
+@patch(f"{_PIPELINE}.reconcile_labels", return_value={"reconciled": 2, "skipped": False})
 @patch(f"{_PIPELINE}.label_clusters", return_value={"labeled": 2, "skipped": 0})
 @patch(f"{_PIPELINE}.select_exemplars", return_value={"exemplars_created": 6, "skipped": 0})
 @patch(f"{_PIPELINE}.cluster_items", return_value={"runs_created": 1, "skipped": 0})
@@ -54,7 +55,7 @@ _PIPELINE = "fluster.pipeline.run"
 @patch(f"{_PIPELINE}.embed_items", return_value={"embedded": 10, "total": 10})
 @patch(f"{_PIPELINE}.materialize_items", return_value={"materialized": 10, "skipped": 0})
 def test_happy_path(
-    mock_mat, mock_emb, mock_red, mock_clu, mock_exe, mock_lab, mock_cri,
+    mock_mat, mock_emb, mock_red, mock_clu, mock_exe, mock_lab, mock_rec, mock_cri,
     conn, plan,
 ):
     _seed_cluster_run(conn, count=1)
@@ -64,13 +65,14 @@ def test_happy_path(
     summary = run_pipeline(conn, project_dir("test-proj"), plan, job_id)
 
     assert summary["completed_steps"] == summary["total_steps"]
-    assert summary["total_steps"] == 7  # 4 + 3*1
+    assert summary["total_steps"] == 8  # 4 + 4*1
     mock_mat.assert_called_once()
     mock_emb.assert_called_once()
     mock_red.assert_called_once()
     mock_clu.assert_called_once()
     mock_exe.assert_called_once()
     mock_lab.assert_called_once()
+    mock_rec.assert_called_once()
     mock_cri.assert_called_once()
 
 
@@ -78,6 +80,7 @@ def test_happy_path(
 
 
 @patch(f"{_PIPELINE}.critique_clusters")
+@patch(f"{_PIPELINE}.reconcile_labels")
 @patch(f"{_PIPELINE}.label_clusters")
 @patch(f"{_PIPELINE}.select_exemplars")
 @patch(f"{_PIPELINE}.cluster_items", return_value={"runs_created": 1, "skipped": 0})
@@ -86,7 +89,7 @@ def test_happy_path(
 @patch(f"{_PIPELINE}.materialize_items", return_value={"materialized": 10, "skipped": 0})
 @patch(f"{_PIPELINE}.is_cancel_requested")
 def test_cancellation_stops_pipeline(
-    mock_cancel, mock_mat, mock_emb, mock_red, mock_clu, mock_exe, mock_lab, mock_cri,
+    mock_cancel, mock_mat, mock_emb, mock_red, mock_clu, mock_exe, mock_lab, mock_rec, mock_cri,
     conn, plan,
 ):
     # Cancel after embed (second cancel check).
@@ -111,6 +114,7 @@ def test_cancellation_stops_pipeline(
 
 
 @patch(f"{_PIPELINE}.critique_clusters", return_value={"critiqued": True, "skipped": False})
+@patch(f"{_PIPELINE}.reconcile_labels", return_value={"reconciled": 2, "skipped": False})
 @patch(f"{_PIPELINE}.label_clusters", return_value={"labeled": 2, "skipped": 0})
 @patch(f"{_PIPELINE}.select_exemplars", return_value={"exemplars_created": 6, "skipped": 0})
 @patch(f"{_PIPELINE}.cluster_items", return_value={"runs_created": 2, "skipped": 0})
@@ -118,7 +122,7 @@ def test_cancellation_stops_pipeline(
 @patch(f"{_PIPELINE}.embed_items", return_value={"embedded": 10, "total": 10})
 @patch(f"{_PIPELINE}.materialize_items", return_value={"materialized": 10, "skipped": 0})
 def test_multiple_cluster_runs(
-    mock_mat, mock_emb, mock_red, mock_clu, mock_exe, mock_lab, mock_cri,
+    mock_mat, mock_emb, mock_red, mock_clu, mock_exe, mock_lab, mock_rec, mock_cri,
     conn, plan,
 ):
     _seed_cluster_run(conn, count=2)
@@ -127,9 +131,10 @@ def test_multiple_cluster_runs(
 
     summary = run_pipeline(conn, project_dir("test-proj"), plan, job_id)
 
-    assert summary["total_steps"] == 10  # 4 + 3*2
+    assert summary["total_steps"] == 12  # 4 + 4*2
     assert mock_exe.call_count == 2
     assert mock_lab.call_count == 2
+    assert mock_rec.call_count == 2
     assert mock_cri.call_count == 2
 
 
@@ -137,6 +142,7 @@ def test_multiple_cluster_runs(
 
 
 @patch(f"{_PIPELINE}.critique_clusters", return_value={"critiqued": True, "skipped": False})
+@patch(f"{_PIPELINE}.reconcile_labels", return_value={"reconciled": 2, "skipped": False})
 @patch(f"{_PIPELINE}.label_clusters", return_value={"labeled": 2, "skipped": 0})
 @patch(f"{_PIPELINE}.select_exemplars", return_value={"exemplars_created": 6, "skipped": 0})
 @patch(f"{_PIPELINE}.cluster_items", return_value={"runs_created": 1, "skipped": 0})
@@ -144,7 +150,7 @@ def test_multiple_cluster_runs(
 @patch(f"{_PIPELINE}.embed_items", return_value={"embedded": 10, "total": 10})
 @patch(f"{_PIPELINE}.materialize_items", return_value={"materialized": 10, "skipped": 0})
 def test_progress_updated(
-    mock_mat, mock_emb, mock_red, mock_clu, mock_exe, mock_lab, mock_cri,
+    mock_mat, mock_emb, mock_red, mock_clu, mock_exe, mock_lab, mock_rec, mock_cri,
     conn, plan,
 ):
     _seed_cluster_run(conn, count=1)
@@ -163,6 +169,7 @@ def test_progress_updated(
 
 
 @patch(f"{_PIPELINE}.critique_clusters", return_value={"critiqued": True, "skipped": False})
+@patch(f"{_PIPELINE}.reconcile_labels", return_value={"reconciled": 2, "skipped": False})
 @patch(f"{_PIPELINE}.label_clusters", return_value={"labeled": 2, "skipped": 0})
 @patch(f"{_PIPELINE}.select_exemplars", return_value={"exemplars_created": 6, "skipped": 0})
 @patch(f"{_PIPELINE}.cluster_items", return_value={"runs_created": 1, "skipped": 0})
@@ -170,7 +177,7 @@ def test_progress_updated(
 @patch(f"{_PIPELINE}.embed_items", return_value={"embedded": 10, "total": 10})
 @patch(f"{_PIPELINE}.materialize_items", return_value={"materialized": 10, "skipped": 0})
 def test_embed_receives_job_id(
-    mock_mat, mock_emb, mock_red, mock_clu, mock_exe, mock_lab, mock_cri,
+    mock_mat, mock_emb, mock_red, mock_clu, mock_exe, mock_lab, mock_rec, mock_cri,
     conn, plan,
 ):
     _seed_cluster_run(conn, count=1)


### PR DESCRIPTION
## Summary

Adds a **label reconciliation** step to the clustering pipeline (issue #21). Per-cluster labeling (`label_clusters`) only ever sees one cluster at a time, so the label set drifts — duplicate/near-duplicate labels, inconsistent granularity and voice, and missed sibling structure ("Cats"/"Dogs" vs. "Domestic Felines"/"Domestic Canines").

The new `reconcile_labels` step (`fluster/pipeline/reconcile.py`) runs once per cluster run, **after labeling and before critique**. It gathers every non-noise cluster's current label info, sends the whole set to the LLM in a single call, and revises labels for consistency and disambiguation. It does **not** re-cluster — only labels change.

## Design

- **Update in place, no schema change.** Revised labels are written back onto the existing `cluster_summaries` row. The latest-row-wins `MAX(cluster_summary_id)` resolution already used by `export`, `server`, and `critique` continues to surface the reconciled label. The pre-reconcile label is preserved under `label_json.original` for provenance.
- **Always on**, matching `label`/`critique` (no plan flag). Per-cluster-run step count goes 3 → 4; progress reporting gains a `reconcile` step.
- **Input is label info only** (label, short_label, keywords, rationale, size) — not raw exemplar text — keeping the single prompt bounded.
- **Idempotent and conservative.** Skips runs already reconciled (guarded by a `label_json.reconciled` flag) and runs with fewer than two clusters. If the LLM omits a cluster, that cluster keeps its original label.

## Tests

- `tests/test_reconcile.py` (new): label updates, idempotency, prompt content, LLM-call logging, downstream latest-row visibility, single-cluster skip, schema validation.
- `tests/test_run.py`: updated step count and call ordering.
- Full suite green: **235 passed**.

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)