### PR TITLE
Teach the plan wizard to configure SOM reductions and codebook clustering

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ fluster init my-project
 # Set up your API key (stored in ~/.fluster/secrets.yaml)
 fluster config
 
-# Tweak the plan if you want (embedding model, LLM, UMAP + clustering params)
+# Tweak the plan if you want (embedding model, LLM, UMAP + clustering, optional SOM grid)
 fluster plan
 
 # Ingest a CSV — file_path column is optional
@@ -146,8 +146,10 @@ fluster use other-project
 Points-on-a-plane (UMAP) is the default way to look at a run. If you'd rather see
 your data laid out on a tidy grid, `fluster` can also train a [self-organizing
 map](https://en.wikipedia.org/wiki/Self-organizing_map) (SOM). It's **opt-in** —
-nothing changes unless you ask for it — so add it to your `plan.yaml` with
-`fluster plan`:
+nothing changes unless you ask for it. Run `fluster plan` and it'll ask whether
+to add a SOM grid (with grid size, sigma, learning rate, iterations) and whether
+to cluster its codebook; answer no later and it cleans both back out. That writes
+a `plan.yaml` like this:
 
 ```yaml
 reductions:

--- a/fluster/cli.py
+++ b/fluster/cli.py
@@ -13,7 +13,15 @@ from rich.table import Table
 
 from fluster import __version__
 from fluster.config import settings
-from fluster.config.plan import load_plan, save_plan, Plan, LLMProvider, UMAPReduction
+from fluster.config.plan import (
+    ClusteringConfig,
+    load_plan,
+    save_plan,
+    Plan,
+    LLMProvider,
+    SOMReduction,
+    UMAPReduction,
+)
 from fluster.config.project import (
     create_project,
     delete_project,
@@ -177,6 +185,26 @@ def config():
     console.print(f"Saved to {settings.SECRETS_FILE}")
 
 
+def _prompt_optional_grid(label: str, current: int | None) -> int | None:
+    """Prompt for a SOM grid dimension; blank input means auto-size (None)."""
+    answer = typer.prompt(
+        f"{label} (blank to auto-size)",
+        default="" if current is None else str(current),
+        show_default=current is not None,
+    ).strip()
+    if not answer:
+        return None
+    try:
+        value = int(answer)
+    except ValueError:
+        console.print(f"[red]{label} must be an integer or blank.[/red]")
+        raise typer.Exit(code=1)
+    if value < 1:
+        console.print(f"[red]{label} must be >= 1.[/red]")
+        raise typer.Exit(code=1)
+    return value
+
+
 @app.command(name="plan")
 def plan_cmd():
     """Interactively edit the clustering plan for the active project."""
@@ -193,7 +221,12 @@ def plan_cmd():
             "LLM model", default=plan.llm.model,
         )
 
-        cluster = plan.clustering[0]
+        # Edit the coordinate-clustering pass; any SOM codebook pass is handled
+        # separately below so the two never clobber each other.
+        cluster = next(
+            (c for c in plan.clustering if c.target == "coordinates"),
+            plan.clustering[0],
+        )
 
         method_choice = typer.prompt(
             "Clustering method (hdbscan/agglomerative)", default=cluster.method,
@@ -292,6 +325,80 @@ def plan_cmd():
                     console.print("[red]target_dimensions must be >= 2.[/red]")
                     raise typer.Exit(code=1)
 
+        # SOM grid reduction (opt-in). Adding a SOM also unlocks two-level
+        # "codebook" clustering, where the grid's nodes are clustered and each
+        # node's cluster propagates to the items whose best-matching unit it is.
+        som = next((r for r in plan.reductions if isinstance(r, SOMReduction)), None)
+        codebook = next((c for c in plan.clustering if c.target == "codebook"), None)
+        if typer.confirm("Add a SOM grid reduction?", default=som is not None):
+            if som is None:
+                som = SOMReduction()
+                plan.reductions.append(som)
+
+            som.grid_x = _prompt_optional_grid("SOM grid_x", som.grid_x)
+            som.grid_y = _prompt_optional_grid("SOM grid_y", som.grid_y)
+
+            som.sigma = typer.prompt("SOM sigma", default=som.sigma, type=float)
+            if som.sigma <= 0.0:
+                console.print("[red]sigma must be > 0.[/red]")
+                raise typer.Exit(code=1)
+
+            som.learning_rate = typer.prompt(
+                "SOM learning_rate", default=som.learning_rate, type=float,
+            )
+            if som.learning_rate <= 0.0:
+                console.print("[red]learning_rate must be > 0.[/red]")
+                raise typer.Exit(code=1)
+
+            som.num_iteration = typer.prompt(
+                "SOM num_iteration", default=som.num_iteration, type=int,
+            )
+            if som.num_iteration < 1:
+                console.print("[red]num_iteration must be >= 1.[/red]")
+                raise typer.Exit(code=1)
+
+            if typer.confirm(
+                "Also cluster the SOM codebook (two-level SOM)?",
+                default=codebook is not None,
+            ):
+                if codebook is None:
+                    codebook = ClusteringConfig(
+                        method="agglomerative", reduction="som_2d", target="codebook",
+                    )
+                    plan.clustering.append(codebook)
+                # Normalize the reference even on the edit path so a hand-edited
+                # plan can't carry a stale reduction past the wizard.
+                codebook.reduction = "som_2d"
+
+                n_clusters = typer.prompt(
+                    "Codebook number of clusters",
+                    default=codebook.params.get("n_clusters", 8), type=int,
+                )
+                if n_clusters < 2:
+                    console.print("[red]n_clusters must be >= 2.[/red]")
+                    raise typer.Exit(code=1)
+
+                linkage = typer.prompt(
+                    "Codebook linkage (ward/complete/average/single)",
+                    default=codebook.params.get("linkage", "ward"),
+                ).strip().lower()
+                if linkage not in ("ward", "complete", "average", "single"):
+                    console.print(f"[red]Invalid linkage '{linkage}'.[/red]")
+                    raise typer.Exit(code=1)
+
+                codebook.params = {"n_clusters": n_clusters, "linkage": linkage}
+            elif codebook is not None:
+                plan.clustering.remove(codebook)
+                codebook = None
+        else:
+            # No SOM: drop the reduction and any codebook pass (it needs a SOM).
+            if som is not None:
+                plan.reductions.remove(som)
+                som = None
+            if codebook is not None:
+                plan.clustering.remove(codebook)
+                codebook = None
+
         caption = plan.images.caption
         caption = typer.confirm("Caption images with FastVLM?", default=caption)
         plan.images.caption = caption
@@ -308,6 +415,18 @@ def plan_cmd():
                 f"  UMAP:        n_neighbors={u.n_neighbors}, "
                 f"min_dist={u.min_dist}, dimensions=[{dims}]"
             )
+        if som is not None:
+            grid = (
+                f"{som.grid_x}x{som.grid_y}"
+                if som.grid_x is not None and som.grid_y is not None else "auto"
+            )
+            console.print(
+                f"  SOM:         grid={grid}, sigma={som.sigma}, "
+                f"learning_rate={som.learning_rate}, num_iteration={som.num_iteration}"
+            )
+        if codebook is not None:
+            cb_params = ", ".join(f"{k}={v}" for k, v in codebook.params.items())
+            console.print(f"  Codebook:    method={codebook.method}, {cb_params}")
         console.print(f"  Images:      caption={'on' if caption else 'off'}")
 
 

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -178,9 +178,9 @@ def test_delete_aborted(named_project):
 def test_plan_sets_umap_options(named_project):
     from fluster.config.plan import load_plan
 
-    # Prompt order: provider, model, method, 4 hdbscan params,
-    # UMAP n_neighbors, UMAP min_dist, target_dims x2, caption confirm.
-    inp = "\n\n\n\n\n\n\n25\n0.2\n\n\ny\n"
+    # Prompt order: provider, model, method, 4 hdbscan params, UMAP n_neighbors,
+    # UMAP min_dist, target_dims x2, "Add a SOM?" confirm (n), caption confirm.
+    inp = "\n\n\n\n\n\n\n25\n0.2\n\n\nn\ny\n"
     result = runner.invoke(app, ["plan"], input=inp)
     assert result.exit_code == 0, result.output
 
@@ -189,6 +189,113 @@ def test_plan_sets_umap_options(named_project):
     assert umaps
     assert all(r.n_neighbors == 25 for r in umaps)
     assert all(r.min_dist == 0.2 for r in umaps)
+
+
+# --- fluster plan: SOM reduction + codebook clustering (issue #25) ---
+
+# Shared prefix answering provider..UMAP target_dims (defaults) up to the
+# "Add a SOM grid reduction?" confirm: 11 blank lines.
+_PLAN_PREFIX = "\n" * 11
+
+
+def test_plan_adds_som_reduction(named_project):
+    from fluster.config.plan import SOMReduction, load_plan
+
+    # SOM yes; grid 8x8; sigma/lr default; num_iteration 500; codebook no; caption default.
+    inp = _PLAN_PREFIX + "y\n8\n8\n\n\n500\nn\n\n"
+    result = runner.invoke(app, ["plan"], input=inp)
+    assert result.exit_code == 0, result.output
+
+    plan = load_plan(project_dir(named_project) / settings.PLAN_YAML)
+    soms = [r for r in plan.reductions if isinstance(r, SOMReduction)]
+    assert len(soms) == 1
+    assert soms[0].grid_x == 8 and soms[0].grid_y == 8
+    assert soms[0].num_iteration == 500
+    assert not any(c.target == "codebook" for c in plan.clustering)
+
+
+def test_plan_som_blank_grid_auto_sizes(named_project):
+    from fluster.config.plan import SOMReduction, load_plan
+
+    # SOM yes; both grid dims blank (auto); all else default; codebook no.
+    inp = _PLAN_PREFIX + "y\n\n\n\n\n\nn\n\n"
+    result = runner.invoke(app, ["plan"], input=inp)
+    assert result.exit_code == 0, result.output
+
+    plan = load_plan(project_dir(named_project) / settings.PLAN_YAML)
+    som = next(r for r in plan.reductions if isinstance(r, SOMReduction))
+    assert som.grid_x is None and som.grid_y is None
+
+
+def test_plan_adds_codebook_clustering(named_project):
+    from fluster.config.plan import load_plan
+
+    # SOM yes (8x8, default sigma/lr, 500 iters); codebook yes (6 clusters, ward).
+    inp = _PLAN_PREFIX + "y\n8\n8\n\n\n500\ny\n6\n\n\n"
+    result = runner.invoke(app, ["plan"], input=inp)
+    assert result.exit_code == 0, result.output
+
+    plan = load_plan(project_dir(named_project) / settings.PLAN_YAML)
+    codebook = [c for c in plan.clustering if c.target == "codebook"]
+    assert len(codebook) == 1
+    assert codebook[0].reduction == "som_2d"
+    assert codebook[0].method == "agglomerative"
+    assert codebook[0].params == {"n_clusters": 6, "linkage": "ward"}
+    # The coordinate clustering pass is left intact.
+    assert any(c.target == "coordinates" for c in plan.clustering)
+
+
+def test_plan_edits_existing_som_in_place(named_project):
+    from fluster.config.plan import Plan, SOMReduction, load_plan, save_plan
+
+    # Seed a plan that already has a SOM, then edit it: the wizard must mutate the
+    # existing reduction (changing num_iteration 500 -> 750), not append a second.
+    plan_path = project_dir(named_project) / settings.PLAN_YAML
+    seeded = Plan()
+    seeded.reductions.append(SOMReduction(grid_x=8, grid_y=8, num_iteration=500))
+    save_plan(seeded, plan_path)
+
+    # SOM confirm defaults to yes (one exists); keep grid/sigma/lr, set iters 750.
+    inp = _PLAN_PREFIX + "\n\n\n\n\n750\nn\n\n"
+    result = runner.invoke(app, ["plan"], input=inp)
+    assert result.exit_code == 0, result.output
+
+    plan = load_plan(plan_path)
+    soms = [r for r in plan.reductions if isinstance(r, SOMReduction)]
+    assert len(soms) == 1
+    assert soms[0].grid_x == 8 and soms[0].grid_y == 8
+    assert soms[0].num_iteration == 750
+
+
+def test_plan_declining_som_removes_existing(named_project):
+    from fluster.config.plan import (
+        ClusteringConfig,
+        Plan,
+        SOMReduction,
+        load_plan,
+        save_plan,
+    )
+
+    # Seed a plan that already has a SOM reduction and a codebook clustering pass.
+    plan_path = project_dir(named_project) / settings.PLAN_YAML
+    seeded = Plan()
+    seeded.reductions.append(SOMReduction(grid_x=8, grid_y=8))
+    seeded.clustering.append(
+        ClusteringConfig(
+            method="agglomerative", reduction="som_2d", target="codebook",
+            params={"n_clusters": 6, "linkage": "ward"},
+        )
+    )
+    save_plan(seeded, plan_path)
+
+    # Decline the SOM; both the reduction and the codebook pass should be dropped.
+    inp = _PLAN_PREFIX + "n\n\n"
+    result = runner.invoke(app, ["plan"], input=inp)
+    assert result.exit_code == 0, result.output
+
+    plan = load_plan(plan_path)
+    assert not any(isinstance(r, SOMReduction) for r in plan.reductions)
+    assert not any(c.target == "codebook" for c in plan.clustering)
 
 
 # --- fluster chill ---


### PR DESCRIPTION
## Summary

The pipeline, database, and client already support self-organizing maps (#13), but the interactive `fluster plan` wizard had no way to set one up — users had to hand-edit `plan.yaml`. This brings the wizard to parity with what the rest of the system can already run.

- **Add a SOM grid reduction?** opt-in step prompts for `grid_x`/`grid_y` (blank → auto-size), `sigma`, `learning_rate`, `num_iteration`, each validated. A new `_prompt_optional_grid` helper centralizes the blank-means-auto behavior.
- Accepting a SOM unlocks **Also cluster the SOM codebook?**, adding an agglomerative `target: codebook` pass (`n_clusters` + `linkage`, validated).
- Fully reversible: declining the SOM later removes both the reduction and any codebook pass; declining only the codebook removes that pass while keeping the SOM.
- The coordinate-clustering edit now selects the `target: coordinates` entry instead of blindly editing `clustering[0]`, so it can't clobber a codebook entry. The codebook `reduction` is normalized to `som_2d` on the edit path too.
- The closing summary prints the SOM/codebook config alongside the UMAP and image lines.

## Tests

5 new tests (add SOM, blank-grid auto-size, add codebook while keeping coordinate clustering, edit existing SOM in place, decline-and-remove a seeded SOM+codebook) plus one existing UMAP test updated for the shifted prompt order. Full suite: **266 passing**.

## Docs

README quick-start and SOM sections updated to note `fluster plan` now drives this end to end.

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)