### PR TITLE
Scope post-cluster steps to the active plan + add `fluster delete-run`

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,11 @@ fluster logs
 # (non-destructive — the source run is left untouched). --force to redo.
 fluster merge --cluster-run 1
 
+# Prune a single stale or orphaned cluster run and its labels, exemplars, and
+# critiques. Leaves embeddings + reductions intact (unlike a full reset), so
+# you don't pay to re-embed. --force to skip the confirmation prompt.
+fluster delete-run 1
+
 # Export results
 fluster export --cluster-run 1 -o results.csv
 

--- a/fluster/cli.py
+++ b/fluster/cli.py
@@ -24,6 +24,7 @@ from fluster.config.project import (
     set_active_project,
 )
 from fluster.db.connection import connect
+from fluster.db.delete_run import delete_cluster_run
 from fluster.db.schema import apply_schema
 from fluster.jobs.manager import (
     create_job,
@@ -492,6 +493,33 @@ def reset():
         apply_schema(conn)
         conn.commit()
         typer.echo("Pipeline outputs cleared. Run 'fluster run' to re-process.")
+
+
+@app.command(name="delete-run")
+def delete_run(
+    cluster_run_id: int = typer.Argument(help="Cluster run ID to delete."),
+    force: bool = typer.Option(False, "--force", help="Skip the confirmation prompt."),
+):
+    """Delete a single cluster run and its labels, exemplars, and critiques.
+
+    Unlike 'reset', this leaves embeddings and reductions intact, so you can
+    prune an orphaned run without forcing a re-embed.
+    """
+    with _open_project() as (_project_path, conn):
+        if not force:
+            typer.confirm(
+                f"Delete cluster run {cluster_run_id} and all its labels, "
+                "exemplars, and critiques?",
+                abort=True,
+            )
+        try:
+            summary = delete_cluster_run(conn, cluster_run_id)
+        except ValueError as exc:
+            logger.error(str(exc))
+            raise typer.Exit(code=1)
+
+        total = sum(summary["deleted"].values())
+        logger.info(f"Deleted cluster run {cluster_run_id} ({total} rows).")
 
 
 @app.command()

--- a/fluster/cli.py
+++ b/fluster/cli.py
@@ -32,6 +32,7 @@ from fluster.config.project import (
     set_active_project,
 )
 from fluster.db.connection import connect
+from fluster.db.delete_run import delete_cluster_run
 from fluster.db.schema import apply_schema
 from fluster.jobs.manager import (
     create_job,
@@ -611,6 +612,33 @@ def reset():
         apply_schema(conn)
         conn.commit()
         typer.echo("Pipeline outputs cleared. Run 'fluster run' to re-process.")
+
+
+@app.command(name="delete-run")
+def delete_run(
+    cluster_run_id: int = typer.Argument(help="Cluster run ID to delete."),
+    force: bool = typer.Option(False, "--force", help="Skip the confirmation prompt."),
+):
+    """Delete a single cluster run and its labels, exemplars, and critiques.
+
+    Unlike 'reset', this leaves embeddings and reductions intact, so you can
+    prune an orphaned run without forcing a re-embed.
+    """
+    with _open_project() as (_project_path, conn):
+        if not force:
+            typer.confirm(
+                f"Delete cluster run {cluster_run_id} and all its labels, "
+                "exemplars, and critiques?",
+                abort=True,
+            )
+        try:
+            summary = delete_cluster_run(conn, cluster_run_id)
+        except ValueError as exc:
+            logger.error(str(exc))
+            raise typer.Exit(code=1)
+
+        total = sum(summary["deleted"].values())
+        logger.info(f"Deleted cluster run {cluster_run_id} ({total} rows).")
 
 
 @app.command()

--- a/fluster/db/delete_run.py
+++ b/fluster/db/delete_run.py
@@ -1,0 +1,47 @@
+"""delete_cluster_run — remove a single cluster run and its dependent rows."""
+
+import sqlite3
+
+# Tables that reference a cluster_run_id, listed child-first so each is emptied
+# before the cluster_runs row it points at is removed (valid under
+# foreign_keys=ON). Embeddings, reductions, and representations are left alone.
+_DEPENDENT_TABLES = (
+    "cluster_run_critiques",
+    "cluster_summaries",
+    "cluster_exemplars",
+    "cluster_assignments",
+)
+
+
+def delete_cluster_run(conn: sqlite3.Connection, cluster_run_id: int) -> dict:
+    """Delete one cluster run and every row that depends on it.
+
+    Removes the run's assignments, exemplars, summaries (labels), and critiques,
+    then the cluster_runs row itself. Does NOT touch embeddings, reductions, or
+    representations, so the next `fluster run` can re-cluster without re-embedding.
+
+    Raises ValueError if the run does not exist. Returns a summary dict mapping
+    each table to the number of rows deleted.
+    """
+    exists = conn.execute(
+        "SELECT 1 FROM cluster_runs WHERE cluster_run_id = ?",
+        (cluster_run_id,),
+    ).fetchone()
+    if exists is None:
+        raise ValueError(f"Cluster run {cluster_run_id} not found.")
+
+    deleted = {}
+    for table in _DEPENDENT_TABLES:
+        cur = conn.execute(
+            f"DELETE FROM {table} WHERE cluster_run_id = ?",
+            (cluster_run_id,),
+        )
+        deleted[table] = cur.rowcount
+    cur = conn.execute(
+        "DELETE FROM cluster_runs WHERE cluster_run_id = ?",
+        (cluster_run_id,),
+    )
+    deleted["cluster_runs"] = cur.rowcount
+    conn.commit()
+
+    return {"cluster_run_id": cluster_run_id, "deleted": deleted}

--- a/fluster/pipeline/cluster.py
+++ b/fluster/pipeline/cluster.py
@@ -49,16 +49,16 @@ def load_coordinates(
     return item_ids, coords
 
 
-def _cluster_run_exists(
+def _find_cluster_run_id(
     conn: sqlite3.Connection, reduction_id: int, method: str, params: dict
-) -> bool:
-    """Check if a cluster run with these exact params already exists."""
+) -> int | None:
+    """Return the id of a cluster run with these exact params, or None."""
     row = conn.execute(
-        "SELECT 1 FROM cluster_runs "
+        "SELECT cluster_run_id FROM cluster_runs "
         "WHERE reduction_id = ? AND method = ? AND params_json = ?",
         (reduction_id, method, json.dumps(params, sort_keys=True)),
     ).fetchone()
-    return row is not None
+    return row["cluster_run_id"] if row else None
 
 
 def cluster_items(
@@ -71,10 +71,14 @@ def cluster_items(
     (e.g. 'umap_8d') and HDBSCAN params. Idempotent — skips runs
     that already exist with identical params.
 
-    Returns a summary dict.
+    Returns a summary dict, including ``cluster_run_ids`` — the ids of every
+    run this plan defines (newly created or already present). Callers use this
+    to scope downstream steps to the active plan rather than every run in the
+    database.
     """
     created = 0
     skipped = 0
+    cluster_run_ids: list[int] = []
 
     for cluster_config in plan.clustering:
         method_name, target_dims = _parse_reduction_ref(cluster_config.reduction)
@@ -89,8 +93,13 @@ def cluster_items(
         reduction_id = reduction["reduction_id"]
         params = cluster_config.params
 
-        if _cluster_run_exists(conn, reduction_id, cluster_config.method, params):
+        existing_id = _find_cluster_run_id(
+            conn, reduction_id, cluster_config.method, params
+        )
+        if existing_id is not None:
             skipped += 1
+            if existing_id not in cluster_run_ids:
+                cluster_run_ids.append(existing_id)
             continue
 
         item_ids, coords = load_coordinates(conn, reduction_id)
@@ -140,9 +149,11 @@ def cluster_items(
 
         conn.commit()
 
+        cluster_run_ids.append(cluster_run_id)
         created += 1
 
     return {
         "runs_created": created,
         "skipped": skipped,
+        "cluster_run_ids": cluster_run_ids,
     }

--- a/fluster/pipeline/run.py
+++ b/fluster/pipeline/run.py
@@ -28,13 +28,6 @@ def _check_cancel(conn: sqlite3.Connection, job_id: int) -> None:
         raise PipelineCancelled(job_id)
 
 
-def _get_all_cluster_run_ids(conn: sqlite3.Connection) -> list[int]:
-    rows = conn.execute(
-        "SELECT cluster_run_id FROM cluster_runs ORDER BY cluster_run_id"
-    ).fetchall()
-    return [r["cluster_run_id"] for r in rows]
-
-
 def run_pipeline(
     conn: sqlite3.Connection,
     project_path: Path,
@@ -87,7 +80,10 @@ def run_pipeline(
     result = cluster_items(conn, plan)
     log_job(conn, job_id, "cluster_items complete", payload=result)
 
-    cluster_run_ids = _get_all_cluster_run_ids(conn)
+    # Scope the post-cluster steps to the runs this plan defines, not every
+    # run ever stored — otherwise orphaned runs from past plan edits get
+    # re-labeled/critiqued on every invocation (see issue #22).
+    cluster_run_ids = result["cluster_run_ids"]
     total_steps = 4 + 3 * len(cluster_run_ids)
     _step("cluster")
     _check_cancel(conn, job_id)

--- a/fluster/server.py
+++ b/fluster/server.py
@@ -12,6 +12,7 @@ from fluster.config import settings
 from fluster.config.plan import load_plan
 from fluster.config.project import project_dir, project_exists
 from fluster.db.connection import connect
+from fluster.db.delete_run import delete_cluster_run
 from fluster.jobs.manager import create_job, get_active_job, get_job, request_cancel
 from fluster.pipeline.merge import merge_clusters
 
@@ -92,6 +93,11 @@ class MergeResponse(BaseModel):
     merges: list[dict] = Field(default_factory=list)
     skipped: bool
     reason: str | None = None
+
+
+class DeleteRunResponse(BaseModel):
+    cluster_run_id: int
+    deleted: dict[str, int]  # table name -> rows removed
 
 
 # ---------------------------------------------------------------------------
@@ -274,6 +280,18 @@ def get_cluster_run(
         labels=labels,
         critique=critique,
     )
+
+
+@router.delete("/cluster-runs/{cluster_run_id}")
+def delete_cluster_run_endpoint(
+    cluster_run_id: int,
+    conn: sqlite3.Connection = Depends(get_conn),
+) -> DeleteRunResponse:
+    try:
+        summary = delete_cluster_run(conn, cluster_run_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+    return DeleteRunResponse(**summary)
 
 
 @router.post("/cluster-runs/{cluster_run_id}/merge")

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -161,6 +161,49 @@ def test_delete_happy_path(named_project):
     assert not project_exists("test-proj")
 
 
+# --- fluster delete-run ---
+
+
+def _seed_cli_run(named_project):
+    """Insert a reduction + cluster run; return the new cluster_run_id."""
+    conn = connect(project_dir(named_project))
+    conn.execute(
+        "INSERT INTO reductions (embedding_reference, method, target_dimensions) "
+        "VALUES ('test', 'umap', 8)"
+    )
+    conn.execute(
+        "INSERT INTO cluster_runs (reduction_id, method, params_json) "
+        "VALUES (1, 'hdbscan', '{}')"
+    )
+    conn.commit()
+    run_id = conn.execute("SELECT cluster_run_id FROM cluster_runs").fetchone()[0]
+    conn.close()
+    return run_id
+
+
+def test_delete_run_happy_path(named_project):
+    run_id = _seed_cli_run(named_project)
+    result = runner.invoke(app, ["delete-run", str(run_id)], input="y\n")
+    assert result.exit_code == 0
+    conn = connect(project_dir(named_project))
+    assert conn.execute("SELECT COUNT(*) FROM cluster_runs").fetchone()[0] == 0
+    conn.close()
+
+
+def test_delete_run_aborted_keeps_run(named_project):
+    run_id = _seed_cli_run(named_project)
+    result = runner.invoke(app, ["delete-run", str(run_id)], input="n\n")
+    assert result.exit_code == 1
+    conn = connect(project_dir(named_project))
+    assert conn.execute("SELECT COUNT(*) FROM cluster_runs").fetchone()[0] == 1
+    conn.close()
+
+
+def test_delete_run_not_found(named_project):
+    result = runner.invoke(app, ["delete-run", "9999", "--force"])
+    assert result.exit_code == 1
+
+
 def test_delete_nonexistent_project(named_project):
     result = runner.invoke(app, ["delete", "ghost"])
     assert result.exit_code == 1

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -243,3 +243,73 @@ def test_agglomerative_is_idempotent(project):
 
     count = conn.execute("SELECT COUNT(*) FROM cluster_runs").fetchone()[0]
     assert count == 1
+
+
+# --- Scoping to the active plan (issue #22) ---
+
+def test_cluster_returns_created_run_id(project):
+    pdir, conn = project
+    _setup_clusterable(pdir, conn)
+
+    summary = cluster_items(conn, Plan())
+
+    run_id = conn.execute(
+        "SELECT cluster_run_id FROM cluster_runs"
+    ).fetchone()["cluster_run_id"]
+    assert summary["cluster_run_ids"] == [run_id]
+
+
+def test_cluster_idempotent_returns_existing_run_id(project):
+    pdir, conn = project
+    _setup_clusterable(pdir, conn)
+
+    first = cluster_items(conn, Plan())
+    second = cluster_items(conn, Plan())
+
+    assert second["runs_created"] == 0
+    assert second["skipped"] == 1
+    # An idempotent re-run still reports the run so downstream steps target it.
+    assert second["cluster_run_ids"] == first["cluster_run_ids"]
+
+
+def test_cluster_dedups_duplicate_configs(project):
+    """A plan listing the same clustering config twice yields one run id."""
+    pdir, conn = project
+    _setup_clusterable(pdir, conn)
+
+    plan = Plan(clustering=[
+        ClusteringConfig(params={"min_cluster_size": 5}),
+        ClusteringConfig(params={"min_cluster_size": 5}),
+    ])
+    summary = cluster_items(conn, plan)
+    assert len(summary["cluster_run_ids"]) == 1
+
+
+def test_cluster_scopes_to_current_plan_excluding_orphans(project):
+    """Switching the plan's clustering must leave the old run out of scope.
+
+    Regression for issue #22: cluster_items must return only the runs the
+    active plan defines, so the post-cluster loop never re-labels an orphan.
+    """
+    pdir, conn = project
+    _setup_clusterable(pdir, conn)
+
+    # The first plan creates an agglomerative run...
+    cluster_items(conn, _agglomerative_plan())
+    orphan_id = conn.execute(
+        "SELECT cluster_run_id FROM cluster_runs"
+    ).fetchone()["cluster_run_id"]
+
+    # ...then the plan switches to hdbscan.
+    summary = cluster_items(conn, Plan())
+
+    all_ids = [
+        r["cluster_run_id"]
+        for r in conn.execute("SELECT cluster_run_id FROM cluster_runs").fetchall()
+    ]
+    # Append-only: the orphaned run still exists in the table...
+    assert orphan_id in all_ids
+    assert len(all_ids) == 2
+    # ...but the current plan only reports its own (hdbscan) run.
+    assert orphan_id not in summary["cluster_run_ids"]
+    assert summary["cluster_run_ids"] == [rid for rid in all_ids if rid != orphan_id]

--- a/tests/test_delete_run.py
+++ b/tests/test_delete_run.py
@@ -1,0 +1,105 @@
+"""Tests for delete_cluster_run (issue #22)."""
+
+import json
+
+import pytest
+
+from fluster.db.delete_run import delete_cluster_run
+
+
+def _seed_run(conn, method="hdbscan"):
+    """Create a reduction + cluster run with a full set of dependent rows.
+
+    Returns the new cluster_run_id.
+    """
+    cur = conn.execute(
+        "INSERT INTO reductions (embedding_reference, method, target_dimensions) "
+        "VALUES ('test', 'umap', 8)"
+    )
+    reduction_id = cur.lastrowid
+    cur = conn.execute(
+        "INSERT INTO cluster_runs (reduction_id, method, params_json) VALUES (?, ?, '{}')",
+        (reduction_id, method),
+    )
+    run_id = cur.lastrowid
+
+    # A row + item to hang assignments/exemplars off of.
+    cur = conn.execute("INSERT INTO rows (row_name) VALUES ('r1')")
+    cur = conn.execute("INSERT INTO items (row_id) VALUES (?)", (cur.lastrowid,))
+    item_id = cur.lastrowid
+
+    conn.execute(
+        "INSERT INTO cluster_assignments "
+        "(cluster_run_id, item_id, cluster_id, membership_probability) "
+        "VALUES (?, ?, 0, 0.9)",
+        (run_id, item_id),
+    )
+    conn.execute(
+        "INSERT INTO cluster_exemplars "
+        "(cluster_run_id, cluster_id, item_id, kind, rank, score) "
+        "VALUES (?, 0, ?, 'center', 1, 0.95)",
+        (run_id, item_id),
+    )
+    conn.execute(
+        "INSERT INTO cluster_summaries "
+        "(cluster_run_id, cluster_id, provider, model, label, label_json) "
+        "VALUES (?, 0, 'openai', 'gpt-5-nano', 'L', ?)",
+        (run_id, json.dumps({"label": "L"})),
+    )
+    conn.execute(
+        "INSERT INTO cluster_run_critiques "
+        "(cluster_run_id, provider, model, critique_json) "
+        "VALUES (?, 'openai', 'gpt-5-nano', ?)",
+        (run_id, json.dumps({"verdict": "ok"})),
+    )
+    conn.commit()
+    return run_id
+
+
+def _counts(conn, run_id):
+    """Row counts across all of a run's tables."""
+    tables = [
+        "cluster_assignments",
+        "cluster_exemplars",
+        "cluster_summaries",
+        "cluster_run_critiques",
+        "cluster_runs",
+    ]
+    return {
+        t: conn.execute(
+            f"SELECT COUNT(*) FROM {t} WHERE cluster_run_id = ?", (run_id,)
+        ).fetchone()[0]
+        for t in tables
+    }
+
+
+def test_delete_removes_only_target_run(project):
+    _pdir, conn = project
+    target = _seed_run(conn)
+    keep = _seed_run(conn)
+
+    summary = delete_cluster_run(conn, target)
+
+    assert summary["cluster_run_id"] == target
+    # Every dependent table reported one row removed, plus the run itself.
+    assert summary["deleted"]["cluster_runs"] == 1
+    assert all(v == 0 for v in _counts(conn, target).values())
+    # The other run is untouched.
+    assert all(v == 1 for v in _counts(conn, keep).values())
+
+
+def test_delete_preserves_embeddings_and_reductions(project):
+    _pdir, conn = project
+    run_id = _seed_run(conn)
+    reductions_before = conn.execute("SELECT COUNT(*) FROM reductions").fetchone()[0]
+
+    delete_cluster_run(conn, run_id)
+
+    # Reductions survive — deletion must not force a re-embed/re-reduce.
+    assert conn.execute("SELECT COUNT(*) FROM reductions").fetchone()[0] == reductions_before
+
+
+def test_delete_missing_run_raises(project):
+    _pdir, conn = project
+    with pytest.raises(ValueError, match="not found"):
+        delete_cluster_run(conn, 9999)

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -25,21 +25,6 @@ def plan(named_project):
     return load_plan(project_dir(named_project) / settings.PLAN_YAML)
 
 
-def _seed_cluster_run(conn, count=1):
-    """Create fake reduction + cluster_run rows."""
-    for _ in range(count):
-        cur = conn.execute(
-            "INSERT INTO reductions (embedding_reference, method, target_dimensions) "
-            "VALUES ('test', 'umap', 8)"
-        )
-        conn.execute(
-            "INSERT INTO cluster_runs (reduction_id, method, params_json) "
-            "VALUES (?, 'hdbscan', '{}')",
-            (cur.lastrowid,),
-        )
-    conn.commit()
-
-
 _PIPELINE = "fluster.pipeline.run"
 
 
@@ -49,7 +34,7 @@ _PIPELINE = "fluster.pipeline.run"
 @patch(f"{_PIPELINE}.critique_clusters", return_value={"critiqued": True, "skipped": False})
 @patch(f"{_PIPELINE}.label_clusters", return_value={"labeled": 2, "skipped": 0})
 @patch(f"{_PIPELINE}.select_exemplars", return_value={"exemplars_created": 6, "skipped": 0})
-@patch(f"{_PIPELINE}.cluster_items", return_value={"runs_created": 1, "skipped": 0})
+@patch(f"{_PIPELINE}.cluster_items", return_value={"runs_created": 1, "skipped": 0, "cluster_run_ids": [1]})
 @patch(f"{_PIPELINE}.reduce_items", return_value={"reductions_created": 2, "skipped": 0})
 @patch(f"{_PIPELINE}.embed_items", return_value={"embedded": 10, "total": 10})
 @patch(f"{_PIPELINE}.materialize_items", return_value={"materialized": 10, "skipped": 0})
@@ -57,7 +42,6 @@ def test_happy_path(
     mock_mat, mock_emb, mock_red, mock_clu, mock_exe, mock_lab, mock_cri,
     conn, plan,
 ):
-    _seed_cluster_run(conn, count=1)
     job_id = create_job(conn, "full_run")
     start_job(conn, job_id)
 
@@ -80,7 +64,7 @@ def test_happy_path(
 @patch(f"{_PIPELINE}.critique_clusters")
 @patch(f"{_PIPELINE}.label_clusters")
 @patch(f"{_PIPELINE}.select_exemplars")
-@patch(f"{_PIPELINE}.cluster_items", return_value={"runs_created": 1, "skipped": 0})
+@patch(f"{_PIPELINE}.cluster_items", return_value={"runs_created": 1, "skipped": 0, "cluster_run_ids": [1]})
 @patch(f"{_PIPELINE}.reduce_items", return_value={"reductions_created": 2, "skipped": 0})
 @patch(f"{_PIPELINE}.embed_items", return_value={"embedded": 10, "total": 10})
 @patch(f"{_PIPELINE}.materialize_items", return_value={"materialized": 10, "skipped": 0})
@@ -92,7 +76,6 @@ def test_cancellation_stops_pipeline(
     # Cancel after embed (second cancel check).
     mock_cancel.side_effect = [False, True]
 
-    _seed_cluster_run(conn, count=1)
     job_id = create_job(conn, "full_run")
     start_job(conn, job_id)
 
@@ -113,7 +96,7 @@ def test_cancellation_stops_pipeline(
 @patch(f"{_PIPELINE}.critique_clusters", return_value={"critiqued": True, "skipped": False})
 @patch(f"{_PIPELINE}.label_clusters", return_value={"labeled": 2, "skipped": 0})
 @patch(f"{_PIPELINE}.select_exemplars", return_value={"exemplars_created": 6, "skipped": 0})
-@patch(f"{_PIPELINE}.cluster_items", return_value={"runs_created": 2, "skipped": 0})
+@patch(f"{_PIPELINE}.cluster_items", return_value={"runs_created": 2, "skipped": 0, "cluster_run_ids": [1, 2]})
 @patch(f"{_PIPELINE}.reduce_items", return_value={"reductions_created": 2, "skipped": 0})
 @patch(f"{_PIPELINE}.embed_items", return_value={"embedded": 10, "total": 10})
 @patch(f"{_PIPELINE}.materialize_items", return_value={"materialized": 10, "skipped": 0})
@@ -121,7 +104,6 @@ def test_multiple_cluster_runs(
     mock_mat, mock_emb, mock_red, mock_clu, mock_exe, mock_lab, mock_cri,
     conn, plan,
 ):
-    _seed_cluster_run(conn, count=2)
     job_id = create_job(conn, "full_run")
     start_job(conn, job_id)
 
@@ -139,7 +121,7 @@ def test_multiple_cluster_runs(
 @patch(f"{_PIPELINE}.critique_clusters", return_value={"critiqued": True, "skipped": False})
 @patch(f"{_PIPELINE}.label_clusters", return_value={"labeled": 2, "skipped": 0})
 @patch(f"{_PIPELINE}.select_exemplars", return_value={"exemplars_created": 6, "skipped": 0})
-@patch(f"{_PIPELINE}.cluster_items", return_value={"runs_created": 1, "skipped": 0})
+@patch(f"{_PIPELINE}.cluster_items", return_value={"runs_created": 1, "skipped": 0, "cluster_run_ids": [1]})
 @patch(f"{_PIPELINE}.reduce_items", return_value={"reductions_created": 2, "skipped": 0})
 @patch(f"{_PIPELINE}.embed_items", return_value={"embedded": 10, "total": 10})
 @patch(f"{_PIPELINE}.materialize_items", return_value={"materialized": 10, "skipped": 0})
@@ -147,7 +129,6 @@ def test_progress_updated(
     mock_mat, mock_emb, mock_red, mock_clu, mock_exe, mock_lab, mock_cri,
     conn, plan,
 ):
-    _seed_cluster_run(conn, count=1)
     job_id = create_job(conn, "full_run")
     start_job(conn, job_id)
 
@@ -165,7 +146,7 @@ def test_progress_updated(
 @patch(f"{_PIPELINE}.critique_clusters", return_value={"critiqued": True, "skipped": False})
 @patch(f"{_PIPELINE}.label_clusters", return_value={"labeled": 2, "skipped": 0})
 @patch(f"{_PIPELINE}.select_exemplars", return_value={"exemplars_created": 6, "skipped": 0})
-@patch(f"{_PIPELINE}.cluster_items", return_value={"runs_created": 1, "skipped": 0})
+@patch(f"{_PIPELINE}.cluster_items", return_value={"runs_created": 1, "skipped": 0, "cluster_run_ids": [1]})
 @patch(f"{_PIPELINE}.reduce_items", return_value={"reductions_created": 2, "skipped": 0})
 @patch(f"{_PIPELINE}.embed_items", return_value={"embedded": 10, "total": 10})
 @patch(f"{_PIPELINE}.materialize_items", return_value={"materialized": 10, "skipped": 0})
@@ -173,7 +154,6 @@ def test_embed_receives_job_id(
     mock_mat, mock_emb, mock_red, mock_clu, mock_exe, mock_lab, mock_cri,
     conn, plan,
 ):
-    _seed_cluster_run(conn, count=1)
     job_id = create_job(conn, "full_run")
     start_job(conn, job_id)
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -193,3 +193,36 @@ def test_get_cluster_run_detail(client, named_project):
     assert len(data["labels"]) == 1
     assert data["labels"][0]["label"] == "Test Cluster"
     assert data["critique"]["verdict"] == "Good."
+
+
+# --- DELETE /cluster-runs/{id} ---
+
+
+def test_delete_cluster_run(client, named_project):
+    conn = connect(project_dir(named_project))
+    conn.execute(
+        "INSERT INTO reductions (embedding_reference, method, target_dimensions) "
+        "VALUES ('test', 'umap', 8)"
+    )
+    reduction_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+    conn.execute(
+        "INSERT INTO cluster_runs (reduction_id, method, params_json) "
+        "VALUES (?, 'hdbscan', '{}')",
+        (reduction_id,),
+    )
+    run_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+    conn.commit()
+    conn.close()
+
+    resp = client.delete(f"/cluster-runs/{run_id}")
+    assert resp.status_code == 200
+    assert resp.json()["cluster_run_id"] == run_id
+    assert resp.json()["deleted"]["cluster_runs"] == 1
+
+    # The run is gone; the detail endpoint now 404s.
+    assert client.get(f"/cluster-runs/{run_id}").status_code == 404
+
+
+def test_delete_cluster_run_not_found(client):
+    resp = client.delete("/cluster-runs/9999")
+    assert resp.status_code == 404


### PR DESCRIPTION
Fixes #22 — `fluster run` was re-running exemplar selection, labeling, and critique for **every** `cluster_runs` row, not just the runs the current plan defines. Because `cluster_items` is append-only, editing `plan.yaml`'s clustering left orphaned runs that got re-labeled/re-critiqued on every run (real LLM spend, worst right after an LLM provider/model switch when idempotency keys stop matching).

## Changes

**1. Scope the post-cluster loop to the active plan** (`607ba4c`)
- `cluster_items` now returns `cluster_run_ids` — exactly the runs the plan defines (freshly created *or* already-present/skipped).
- `run_pipeline` iterates that list instead of the removed `_get_all_cluster_run_ids`, which walked the whole table.
- `_cluster_run_exists` → `_find_cluster_run_id` (returns the id so skipped runs stay in scope).

**2. `fluster delete-run <id>` to prune a single run** (`8b3a5d7`)
- New `delete_cluster_run()` removes one run + its critiques/summaries/exemplars/assignments (child-first, atomic), raising `ValueError` if absent. **Leaves embeddings/reductions/representations intact** — unlike `reset`, no re-embed.
- Exposed via CLI (`fluster delete-run <id>`, `--force`), HTTP (`DELETE /cluster-runs/{id}`, 404 if missing), and README — mirroring how `merge` is surfaced.

## Acceptance criteria
- [x] `fluster run` only labels/critiques the cluster runs the current plan defines.
- [x] Documented way to delete a single cluster run + dependent rows, without clearing embeddings/reductions.
- [x] Tests cover: re-running after editing `plan.yaml`'s clustering doesn't reprocess the orphan; single-run deletion removes exactly that run's rows and preserves reductions.

## Testing
Full suite green — **240 passed**.

## Notes
Deleting a run that is the *parent* of a merged run leaves that merged child in place (its parent link lives in `params_json`, no FK); deletion stays single-run by design — the child can be deleted on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)